### PR TITLE
docs: enable badges, fix release attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,14 +119,19 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      github.event_name == 'push'
+      && startsWith(github.ref, 'refs/tags/v')
+      && !contains(github.ref_name, 'dev')
+      && !contains(github.ref_name, 'rc')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
       name: pypi
       url: https://pypi.org/project/geek42/
     permissions:
-      id-token: write  # OIDC for trusted publishing
+      id-token: write      # OIDC for trusted publishing
+      attestations: write  # PEP 740 publish attestations
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
@@ -158,14 +163,18 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     needs: build
-    if: github.event_name == 'workflow_dispatch' && inputs.testpypi
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.testpypi)
+      || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+          && (contains(github.ref_name, 'dev') || contains(github.ref_name, 'rc')))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
       name: testpypi
       url: https://test.pypi.org/project/geek42/
     permissions:
-      id-token: write
+      id-token: write      # OIDC for trusted publishing
+      attestations: write  # PEP 740 publish attestations
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
@@ -196,8 +205,13 @@ jobs:
   # -------------------------------------------------------------------
   github-release:
     name: Create GitHub Release
-    needs: [build, publish-pypi]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [build, publish-pypi, publish-testpypi]
+    if: >-
+      always()
+      && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      && needs.build.result == 'success'
+      && (needs.publish-pypi.result == 'success' || needs.publish-pypi.result == 'skipped')
+      && (needs.publish-testpypi.result == 'success' || needs.publish-testpypi.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -234,7 +248,7 @@ jobs:
           name: "geek42 ${{ steps.notes.outputs.version }}"
           body_path: release-notes.md
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(github.ref_name, '-') || contains(github.ref_name, 'dev') || contains(github.ref_name, 'rc') }}
           generate_release_notes: true
           files: |
             release-dist/dist/geek42-*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,12 @@ jobs:
           sha256sum geek42-*.whl geek42-*.tar.gz > SHA256SUMS.txt
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: "dist/geek42-*.whl,dist/geek42-*.tar.gz"
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v1.4.1
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: "dist/geek42-*.whl"
           sbom-path: "dist/geek42-sbom.cdx.json"
@@ -94,9 +94,9 @@ jobs:
 
   # -------------------------------------------------------------------
   # SLSA Level 3 provenance generator (reusable workflow).
-  # TODO: temporarily disabled — causes startup_failure. Likely needs
-  # additional repo-level permissions or configuration for the
-  # slsa-framework reusable workflow. Re-enable once resolved.
+  # TODO: causes startup_failure — needs investigation.
+  # Build provenance is handled by actions/attest in the build job
+  # (same approach as slsa-battleground).
   # See: https://github.com/slsa-framework/slsa-github-generator
   # -------------------------------------------------------------------
   # provenance:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
 # geek42
 
+<!-- build & packaging -->
+[![PyPI](https://img.shields.io/pypi/v/geek42)](https://pypi.org/project/geek42/)
+[![Python](https://img.shields.io/pypi/pyversions/geek42)](https://pypi.org/project/geek42/)
+[![Downloads](https://img.shields.io/pypi/dm/geek42)](https://pypi.org/project/geek42/)
 [![CI](https://github.com/IvanAnishchuk/geek42/actions/workflows/ci.yml/badge.svg)](https://github.com/IvanAnishchuk/geek42/actions/workflows/ci.yml)
+[![Coverage](https://raw.githubusercontent.com/IvanAnishchuk/geek42/python-coverage-comment-action-data/badge.svg)](https://github.com/IvanAnishchuk/geek42/tree/python-coverage-comment-action-data)
+[![Release](https://img.shields.io/github/v/release/IvanAnishchuk/geek42)](https://github.com/IvanAnishchuk/geek42/releases/latest)
+
+<!-- security & quality -->
 [![CodeQL](https://github.com/IvanAnishchuk/geek42/actions/workflows/codeql.yml/badge.svg)](https://github.com/IvanAnishchuk/geek42/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/IvanAnishchuk/geek42/badge)](https://scorecard.dev/viewer/?uri=github.com/IvanAnishchuk/geek42)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12450/badge)](https://www.bestpractices.dev/projects/12450)
-[![License: CC0-1.0](https://img.shields.io/badge/license-CC0--1.0-lightgrey)](LICENSE.md)
-[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 
-<!-- Uncomment after PyPI publish and first successful coverage run:
-[![PyPI](https://img.shields.io/pypi/v/geek42)](https://pypi.org/project/geek42/)
-[![Python](https://img.shields.io/pypi/pyversions/geek42)](https://pypi.org/project/geek42/)
-[![Coverage](https://raw.githubusercontent.com/IvanAnishchuk/geek42/python-coverage-comment-action-data/badge.svg)](https://github.com/IvanAnishchuk/geek42/tree/python-coverage-comment-action-data)
--->
+<!-- tooling & standards -->
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![ruff](https://img.shields.io/badge/ruff-%E2%89%A50.11-blue)](https://github.com/astral-sh/ruff)
+[![ty](https://img.shields.io/badge/ty-0.x-blue)](https://github.com/astral-sh/ty)
+[![yamllint](https://img.shields.io/badge/yamllint-checked-blue)](https://github.com/adrienverge/yamllint)
+[![mdformat](https://img.shields.io/badge/mdformat-formatted-blue)](https://github.com/executablebooks/mdformat)
+[![SemVer](https://img.shields.io/badge/SemVer-2.0.0-blue)](https://semver.org)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![Immutable Releases](https://img.shields.io/badge/releases-immutable-blue)](https://github.com/IvanAnishchuk/geek42/releases)
+[![SLOC](https://img.shields.io/badge/SLOC-~2.6k-informational)](src/geek42/)
+[![License: CC0-1.0](https://img.shields.io/badge/license-CC0--1.0-lightgrey)](LICENSE.md)
 
 Convert [GLEP 42](https://www.gentoo.org/glep/glep-0042.html) Gentoo news repositories into a static blog with RSS/Atom feeds, Markdown exports, and a terminal reader — no `eselect news` required.
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@
 [![yamllint](https://img.shields.io/badge/yamllint-checked-blue)](https://github.com/adrienverge/yamllint)
 [![mdformat](https://img.shields.io/badge/mdformat-formatted-blue)](https://github.com/executablebooks/mdformat)
 [![SemVer](https://img.shields.io/badge/SemVer-2.0.0-blue)](https://semver.org)
-[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+[![commits: conventional](https://img.shields.io/badge/commits-conventional-blue)](https://conventionalcommits.org)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
-[![Immutable Releases](https://img.shields.io/badge/releases-immutable-blue)](https://github.com/IvanAnishchuk/geek42/releases)
+[![releases: immutable](https://img.shields.io/badge/releases-immutable-blue)](https://github.com/IvanAnishchuk/geek42/releases)
+[![attestations: verified](https://img.shields.io/badge/attestations-verified-blue)](https://github.com/IvanAnishchuk/geek42/attestations)
 [![SLOC](https://img.shields.io/badge/SLOC-~2.6k-informational)](src/geek42/)
 [![License: CC0-1.0](https://img.shields.io/badge/license-CC0--1.0-lightgrey)](LICENSE.md)
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12450/badge)](https://www.bestpractices.dev/projects/12450)
 
 <!-- tooling & standards -->
-[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![ruff](https://img.shields.io/badge/ruff-%E2%89%A50.11-blue)](https://github.com/astral-sh/ruff)
-[![ty](https://img.shields.io/badge/ty-0.x-blue)](https://github.com/astral-sh/ty)
+[![uv](https://img.shields.io/badge/uv-0.11.5-blue)](https://github.com/astral-sh/uv)
+[![ruff](https://img.shields.io/badge/ruff-0.15.10-blue)](https://github.com/astral-sh/ruff)
+[![ty](https://img.shields.io/badge/ty-0.0.29-blue)](https://github.com/astral-sh/ty)
 [![yamllint](https://img.shields.io/badge/yamllint-checked-blue)](https://github.com/adrienverge/yamllint)
 [![mdformat](https://img.shields.io/badge/mdformat-formatted-blue)](https://github.com/executablebooks/mdformat)
 [![SemVer](https://img.shields.io/badge/SemVer-2.0.0-blue)](https://semver.org)


### PR DESCRIPTION
## Summary

- Enable all README badges now that v0.4.1 is published on PyPI
- Switch to unified `actions/attest@v4.1.0` (replaces `attest-build-provenance` + `attest-sbom`)
- Add `attestations: write` permission for PEP 740 publish attestations
- Route dev/rc tags to TestPyPI, skip PyPI for pre-releases
- Fix github-release job to handle skipped publish jobs gracefully
- Update tool version badges (uv 0.11.5, ruff 0.15.10, ty 0.0.29)
- Add attestations badge

Closes #10

## Test plan

- [x] Badge rendering verified on GitHub
- [x] Attestations tested successfully with v0.1.0.dev2 on dev-test branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)