### PR TITLE
chore(release): v0.4.2a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2a1] - 2026-04-11
+
+### Changed
+
+- Switch to unified `actions/attest@v4.1.0` for build provenance and
+  SBOM attestations (replaces `attest-build-provenance` + `attest-sbom`).
+- Add `attestations: write` permission to publish jobs for PEP 740
+  publish attestations.
+- Route dev/rc version tags to TestPyPI instead of PyPI.
+- Enable all README badges (PyPI, coverage, release, tooling versions,
+  attestations).
+
 ## [0.4.1] - 2026-04-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geek42"
-version = "0.4.1"
+version = "0.4.2a1"
 description = "Convert GLEP 42 Gentoo news repositories into static blogs"
 readme = "README.md"
 license = "CC0-1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -256,7 +256,7 @@ wheels = [
 
 [[package]]
 name = "geek42"
-version = "0.4.1"
+version = "0.4.2a1"
 source = { editable = "." }
 dependencies = [
     { name = "gemato" },


### PR DESCRIPTION
## Summary

- Bump version to `0.4.2a1`
- Unified `actions/attest@v4.1.0` for provenance and SBOM attestations
- `attestations: write` on publish jobs for PEP 740 attestations
- Dev/rc tags route to TestPyPI
- All README badges enabled with exact tool versions
- Attestations badge added

## Test plan

- [x] Attestations verified working with v0.1.0.dev2 on dev-test branch
- [ ] Tag `v0.4.2a1` after merge and verify release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)