### PR TITLE
chore(release): v0.4.2a2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,9 @@ jobs:
       github.event_name == 'push'
       && startsWith(github.ref, 'refs/tags/v')
       && !contains(github.ref_name, 'dev')
-      && !contains(github.ref_name, 'rc')
+      && !contains(github.ref_name, 'a')
+      && !contains(github.ref_name, 'b')
+      && !contains(github.ref_name, 'c')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -166,7 +168,8 @@ jobs:
     if: >-
       (github.event_name == 'workflow_dispatch' && inputs.testpypi)
       || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-          && (contains(github.ref_name, 'dev') || contains(github.ref_name, 'rc')))
+          && (contains(github.ref_name, 'dev') || contains(github.ref_name, 'a')
+              || contains(github.ref_name, 'b') || contains(github.ref_name, 'c')))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -248,7 +251,7 @@ jobs:
           name: "geek42 ${{ steps.notes.outputs.version }}"
           body_path: release-notes.md
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-') || contains(github.ref_name, 'dev') || contains(github.ref_name, 'rc') }}
+          prerelease: ${{ contains(github.ref_name, 'dev') || contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'c') }}
           generate_release_notes: true
           files: |
             release-dist/dist/geek42-*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN uv sync --frozen --no-dev
 FROM python:${PYTHON_VERSION}-${DEBIAN_SUITE} AS runtime
 
 # OCI image labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
-ARG VERSION=0.2.0
+ARG VERSION=0.4.2a2
 ARG REVISION=unknown
 ARG BUILD_DATE=unknown
 LABEL org.opencontainers.image.title="geek42" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geek42"
-version = "0.4.2a1"
+version = "0.4.2a2"
 description = "Convert GLEP 42 Gentoo news repositories into static blogs"
 readme = "README.md"
 license = "CC0-1.0"

--- a/src/geek42/__init__.py
+++ b/src/geek42/__init__.py
@@ -42,7 +42,7 @@ from .renderer import body_to_html, news_to_markdown, write_markdown
 from .scaffold import scaffold
 from .tracker import ReadTracker
 
-__version__ = "0.4.1"
+__version__ = "0.4.2a2"
 
 __all__ = [
     "ComposeError",

--- a/uv.lock
+++ b/uv.lock
@@ -256,7 +256,7 @@ wheels = [
 
 [[package]]
 name = "geek42"
-version = "0.4.2a1"
+version = "0.4.2a2"
 source = { editable = "." }
 dependencies = [
     { name = "gemato" },


### PR DESCRIPTION
## Summary

- Fix pre-release routing: handle all PEP 440 suffixes (`a`/`b`/`c`/`dev`)
- Bump version to `0.4.2a2` in pyproject.toml, `__init__.py`, and Dockerfile
- v0.4.2a1 incorrectly routed to PyPI because `a` suffix wasn't detected

## Test plan

- [ ] Merge, tag `v0.4.2a2`, verify it routes to TestPyPI (not PyPI)
- [ ] Verify attestations pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)