### PR TITLE
fix(ci): simplify environment deployment branch policies

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -133,7 +133,6 @@ environments:
       custom_branch_policies: true
       custom_branches:
         - main
-        - "v*.*.*"
   - name: testpypi
     wait_timer: 0
     deployment_branch_policy:


### PR DESCRIPTION
## Summary

- Remove tag patterns from pypi/testpypi environment branch policies
- `custom_branch_policies` only matches branches, not tags
- Tag-based deployment rules configured in GitHub UI

Needed to unblock v0.4.2a2 TestPyPI publish.

## Test plan

- [ ] Merge, rerun v0.4.2a2 release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)