### PR TITLE
fix(ci): remove deployment branch policies from environments

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -128,15 +128,5 @@ branches:
 environments:
   - name: pypi
     wait_timer: 0
-    deployment_branch_policy:
-      protected_branches: false
-      custom_branch_policies: true
-      custom_branches:
-        - main
   - name: testpypi
     wait_timer: 0
-    deployment_branch_policy:
-      protected_branches: false
-      custom_branch_policies: true
-      custom_branches:
-        - main


### PR DESCRIPTION
## Summary

Remove `deployment_branch_policy` from pypi and testpypi environments.
Custom branch policies only match branches, not tags, blocking all
tag-based releases.

## Test plan

- [ ] Merge, rerun v0.4.2a3 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)