### PR TITLE
chore(release): v0.4.2a4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN uv sync --frozen --no-dev
 FROM python:${PYTHON_VERSION}-${DEBIAN_SUITE} AS runtime
 
 # OCI image labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
-ARG VERSION=0.4.2a3
+ARG VERSION=0.4.2a4
 ARG REVISION=unknown
 ARG BUILD_DATE=unknown
 LABEL org.opencontainers.image.title="geek42" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geek42"
-version = "0.4.2a3"
+version = "0.4.2a4"
 description = "Convert GLEP 42 Gentoo news repositories into static blogs"
 readme = "README.md"
 license = "CC0-1.0"

--- a/src/geek42/__init__.py
+++ b/src/geek42/__init__.py
@@ -42,7 +42,7 @@ from .renderer import body_to_html, news_to_markdown, write_markdown
 from .scaffold import scaffold
 from .tracker import ReadTracker
 
-__version__ = "0.4.2a3"
+__version__ = "0.4.2a4"
 
 __all__ = [
     "ComposeError",

--- a/uv.lock
+++ b/uv.lock
@@ -256,7 +256,7 @@ wheels = [
 
 [[package]]
 name = "geek42"
-version = "0.4.2a3"
+version = "0.4.2a4"
 source = { editable = "." }
 dependencies = [
     { name = "gemato" },


### PR DESCRIPTION
## Summary

- Bump version to `0.4.2a4`
- First release with SLSA L3 provenance enabled

## Test plan

- [ ] Merge, tag `v0.4.2a4`, verify full pipeline (attestations + SLSA + TestPyPI + GitHub Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)