### PR TITLE
chore(release): v0.4.2a6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN uv sync --frozen --no-dev
 FROM python:${PYTHON_VERSION}-${DEBIAN_SUITE} AS runtime
 
 # OCI image labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
-ARG VERSION=0.4.2a5
+ARG VERSION=0.4.2a6
 ARG REVISION=unknown
 ARG BUILD_DATE=unknown
 LABEL org.opencontainers.image.title="geek42" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geek42"
-version = "0.4.2a5"
+version = "0.4.2a6"
 description = "Convert GLEP 42 Gentoo news repositories into static blogs"
 readme = "README.md"
 license = "CC0-1.0"

--- a/src/geek42/__init__.py
+++ b/src/geek42/__init__.py
@@ -42,7 +42,7 @@ from .renderer import body_to_html, news_to_markdown, write_markdown
 from .scaffold import scaffold
 from .tracker import ReadTracker
 
-__version__ = "0.4.2a5"
+__version__ = "0.4.2a6"
 
 __all__ = [
     "ComposeError",

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "geek42"
-version = "0.4.2a5"
+version = "0.4.2a6"
 source = { editable = "." }
 dependencies = [
     { name = "gemato" },


### PR DESCRIPTION
## Summary

- Bump version to `0.4.2a6`
- First release with versioned proof filenames and PEP 740 verification

## Test plan

- [ ] Merge, tag, verify full pipeline
- [ ] Run `uv run scripts/verify_provenance.py 0.4.2a6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)