### PR TITLE
fix(ci): versioned SBOM path for attest + v0.4.2a7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,15 @@ jobs:
           subject-path: "dist/geek42-*.whl,dist/geek42-*.tar.gz"
 
       - name: Attest SBOM
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "sbom_path=dist/geek42-${VERSION}-sbom.cdx.json" >> "$GITHUB_ENV"
+
+      - name: Attest SBOM (upload)
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: "dist/geek42-*.whl"
-          sbom-path: "dist/geek42-*-sbom.cdx.json"
+          sbom-path: "${{ env.sbom_path }}"
 
       - name: Sign artifacts with sigstore
         uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc # v3.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN uv sync --frozen --no-dev
 FROM python:${PYTHON_VERSION}-${DEBIAN_SUITE} AS runtime
 
 # OCI image labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
-ARG VERSION=0.4.2a6
+ARG VERSION=0.4.2a7
 ARG REVISION=unknown
 ARG BUILD_DATE=unknown
 LABEL org.opencontainers.image.title="geek42" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geek42"
-version = "0.4.2a6"
+version = "0.4.2a7"
 description = "Convert GLEP 42 Gentoo news repositories into static blogs"
 readme = "README.md"
 license = "CC0-1.0"

--- a/src/geek42/__init__.py
+++ b/src/geek42/__init__.py
@@ -42,7 +42,7 @@ from .renderer import body_to_html, news_to_markdown, write_markdown
 from .scaffold import scaffold
 from .tracker import ReadTracker
 
-__version__ = "0.4.2a6"
+__version__ = "0.4.2a7"
 
 __all__ = [
     "ComposeError",

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "geek42"
-version = "0.4.2a6"
+version = "0.4.2a7"
 source = { editable = "." }
 dependencies = [
     { name = "gemato" },


### PR DESCRIPTION
## Summary

- Fix SBOM attestation: `sbom-path` doesn't support globs, use env var
- Bump to v0.4.2a7

v0.4.2a6 failed at "Attest SBOM" because `dist/geek42-*-sbom.cdx.json`
wasn't expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)