### PR TITLE
chore: bump packaging stubs to 0.4.2a7

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -7,7 +7,7 @@ distribution:
 | Path | Target | Tool |
 |------|--------|------|
 | `debian/` | Debian / Ubuntu `.deb` | `dpkg-buildpackage` / `sbuild` |
-| `rpm/geek42.spec` | Fedora / RHEL / openSUSE `.rpm` | `rpmbuild` / `mock` |
+| `rpm/geek42.spec` | CentOS / RHEL / Fedora `.rpm` | `rpmbuild` / `mock` |
 | `gentoo/app-text/geek42/` | Gentoo ebuild | `pkgdev manifest` + overlay |
 | `../Dockerfile` | OCI container image | `docker build` / `podman build` |
 
@@ -30,7 +30,7 @@ dpkg-buildpackage -us -uc -b
 The resulting `.deb` lands in the parent directory. Install with:
 
 ```sh
-sudo dpkg -i ../geek42_0.2.0-1_all.deb
+sudo dpkg -i ../geek42_0.4.2~a7-1_all.deb
 ```
 
 ### Maintainer notes
@@ -42,7 +42,7 @@ sudo dpkg -i ../geek42_0.2.0-1_all.deb
 
 ---
 
-## Fedora / RHEL / openSUSE
+## CentOS / RHEL / Fedora
 
 The `rpm/geek42.spec` file follows the
 [Fedora Python packaging guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/)
@@ -56,7 +56,7 @@ rpmbuild -bs packaging/rpm/geek42.spec \
 
 # Or using mock for a clean chroot build
 mock --buildsrpm --spec packaging/rpm/geek42.spec --sources $PWD
-mock --rebuild build/geek42-0.2.0-1.fc*.src.rpm
+mock --rebuild build/geek42-0.4.2~a7-1.*.src.rpm
 ```
 
 ### Maintainer notes
@@ -69,8 +69,8 @@ mock --rebuild build/geek42-0.2.0-1.fc*.src.rpm
 
 ## Gentoo
 
-The ebuild at `gentoo/app-text/geek42/geek42-0.2.0.ebuild` is ready
-to be dropped into any Gentoo overlay.
+The ebuilds at `gentoo/app-text/geek42/` are ready to be dropped
+into any Gentoo overlay.
 
 ```sh
 # Assuming you have a personal overlay at /var/db/repos/myoverlay
@@ -103,10 +103,10 @@ See [`../Dockerfile`](../Dockerfile) in the repo root.
 ```sh
 # Build
 docker build \
-    --build-arg VERSION=0.2.0 \
+    --build-arg VERSION=0.4.2a7 \
     --build-arg REVISION=$(git rev-parse HEAD) \
     --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
-    -t geek42:0.2.0 -t geek42:latest .
+    -t geek42:0.4.2a7 -t geek42:latest .
 
 # Run (mounts current dir as /work inside the container)
 docker run --rm -v "$PWD:/work" geek42:latest --help

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,20 @@
+geek42 (0.4.2~a7-1) unstable; urgency=medium
+
+  * New upstream pre-release.
+  * SLSA L3 provenance enabled.
+  * PEP 740 attestation verification.
+  * Versioned proof filenames.
+  * See CHANGELOG.md for details.
+
+ -- Ivan Anishchuk <ivan@agorism.org>  Fri, 11 Apr 2026 00:00:00 +0000
+
+geek42 (0.4.1-1) unstable; urgency=medium
+
+  * Fix release workflow, re-enable attestations.
+  * See CHANGELOG.md for details.
+
+ -- Ivan Anishchuk <ivan@agorism.org>  Fri, 11 Apr 2026 00:00:00 +0000
+
 geek42 (0.4.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/packaging/gentoo/app-text/geek42/geek42-0.4.2_alpha7.ebuild
+++ b/packaging/gentoo/app-text/geek42/geek42-0.4.2_alpha7.ebuild
@@ -1,0 +1,57 @@
+# Copyright 2026 geek42 contributors
+# Distributed under the terms of the Creative Commons Zero v1.0 Universal license
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=hatchling
+PYTHON_COMPAT=( python3_{13,14} )
+
+inherit distutils-r1 pypi
+
+DESCRIPTION="Convert GLEP 42 Gentoo news repositories into static blogs"
+HOMEPAGE="
+	https://github.com/IvanAnishchuk/geek42
+	https://pypi.org/project/geek42/
+"
+
+LICENSE="CC0-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
+
+RDEPEND="
+	dev-vcs/git
+	app-portage/gemato
+	>=dev-python/pydantic-2.0[${PYTHON_USEDEP}]
+	>=dev-python/jinja2-3.1[${PYTHON_USEDEP}]
+	>=dev-python/typer-0.15[${PYTHON_USEDEP}]
+	>=dev-python/rich-13.0[${PYTHON_USEDEP}]
+	>=dev-python/markdown-3.5[${PYTHON_USEDEP}]
+	>=dev-python/gemato-20[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	test? (
+		>=dev-python/pytest-8.0[${PYTHON_USEDEP}]
+		dev-python/pytest-cov[${PYTHON_USEDEP}]
+	)
+"
+
+distutils_enable_tests pytest
+
+python_install_all() {
+	local DOCS=( README.md CHANGELOG.md SECURITY.md )
+	local HTML_DOCS=( docs/. )
+	distutils-r1_python_install_all
+}
+
+pkg_postinst() {
+	elog "geek42 is installed as an alternative to eselect news."
+	elog ""
+	elog "To get started:"
+	elog "  geek42 init"
+	elog "  \$EDITOR geek42.toml   # configure your news sources"
+	elog "  geek42 pull"
+	elog "  geek42 list"
+	elog "  geek42 read-new       # equivalent to 'eselect news read new'"
+	elog ""
+	elog "See /usr/share/doc/${PF}/ for full documentation."
+}

--- a/packaging/rpm/geek42.spec
+++ b/packaging/rpm/geek42.spec
@@ -7,7 +7,7 @@ read/unread tracking, compose and revise workflows, and a built-in
 news file linter with 15 diagnostic rules.}
 
 Name:           %{pypi_name}
-Version:        0.4.0
+Version:        0.4.2~a7
 Release:        1%{?dist}
 Summary:        GLEP 42 Gentoo news to static blog converter
 
@@ -66,6 +66,21 @@ Summary:        %{summary}
 - New upstream release.
 - Adds compose/revise/read-new commands.
 - Full supply-chain security hardening.
+
+* Fri Apr 11 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.2~a7-1
+- Pre-release: SLSA L3 provenance, PEP 740 attestations, versioned proofs.
+
+* Fri Apr 11 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.1-1
+- Fix release workflow, re-enable attestations.
+
+* Fri Apr 10 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.0-1
+- New upstream release with commit/push/sign/verify/deploy-status commands.
+
+* Fri Apr 10 2026 Ivan Anishchuk <ivan@agorism.org> - 0.3.0-1
+- Adds --directory / -C option to all commands.
+
+* Thu Apr 09 2026 Ivan Anishchuk <ivan@agorism.org> - 0.2.0-1
+- Adds compose/revise/read-new commands, supply-chain security hardening.
 
 * Thu Apr 09 2026 Ivan Anishchuk <ivan@agorism.org> - 0.1.0-1
 - Initial release.


### PR DESCRIPTION
## Summary

- `packaging/debian/changelog`: add 0.4.1 and 0.4.2~a7 entries
- `packaging/rpm/geek42.spec`: bump to 0.4.2~a7, add full changelog
- `packaging/gentoo/`: add `geek42-0.4.2_alpha7.ebuild`
- `packaging/README.md`: update version references, CentOS instead of openSUSE

## Test plan

- [x] All version strings consistent across packaging files

🤖 Generated with [Claude Code](https://claude.com/claude-code)