### PR TITLE
fix: uniform hash display in all verification scripts

### DIFF
--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -136,14 +136,15 @@ def verify_sigstore_blob(path: Path, bundle: Path, version: str) -> bool:
             str(path),
         ])
 
+    artifact_hash = sha256(path)
     if result.returncode != 0:
         fail(f"cosign verify-blob: {path.name}")
+        fail(f"  artifact: {artifact_hash}")
         if result.stderr:
-            for line in result.stderr.strip().splitlines():
-                fail(f"  {line}")
+            fail(f"  error: {result.stderr.strip().splitlines()[-1]}")
         return False
 
-    ok(f"cosign verify-blob: {path.name}")
+    ok(f"cosign verify-blob: {path.name} ({artifact_hash})")
     info(f"  identity: {identity}")
     return True
 
@@ -164,14 +165,15 @@ def verify_slsa_attestation(path: Path, provenance: Path) -> bool:
         "--bundle", str(provenance),
         str(path),
     ])
+    artifact_hash = sha256(path)
     if result.returncode != 0:
-        fail(f"cosign verify-blob-attestation: {path.name}")
+        fail(f"cosign SLSA L3: {path.name}")
+        fail(f"  artifact: {artifact_hash}")
         if result.stderr:
-            for line in result.stderr.strip().splitlines():
-                fail(f"  {line}")
+            fail(f"  error: {result.stderr.strip().splitlines()[-1]}")
         return False
 
-    ok(f"cosign verify-blob-attestation: {path.name} (SLSA L3)")
+    ok(f"cosign SLSA L3: {path.name} ({artifact_hash})")
     return True
 
 
@@ -209,14 +211,15 @@ def verify_gh_attestation(path: Path, att_file: Path, version: str) -> bool:
         "--bundle", str(extracted),
         str(path),
     ])
+    artifact_hash = sha256(path)
     if result.returncode != 0:
         fail(f"cosign GH attestation: {path.name}")
+        fail(f"  artifact: {artifact_hash}")
         if result.stderr:
-            for line in result.stderr.strip().splitlines():
-                fail(f"  {line}")
+            fail(f"  error: {result.stderr.strip().splitlines()[-1]}")
         return False
 
-    ok(f"cosign GH attestation: {path.name}")
+    ok(f"cosign GH attestation: {path.name} ({artifact_hash})")
     info(f"  identity: {identity}")
     return True
 
@@ -273,15 +276,16 @@ def verify_pypi_attestation(path: Path, provenance: dict, index_name: str) -> bo
                 "--bundle", str(extracted),
                 str(path),
             ])
+            artifact_hash = sha256(path)
             if result.returncode != 0:
                 fail(f"cosign {index_name} PEP 740: {path.name}")
+                fail(f"  artifact: {artifact_hash}")
                 if result.stderr:
-                    for line in result.stderr.strip().splitlines():
-                        fail(f"  {line}")
+                    fail(f"  error: {result.stderr.strip().splitlines()[-1]}")
                 all_ok = False
             else:
                 publisher = bundle_data.get("publisher", {})
-                ok(f"cosign {index_name} PEP 740: {path.name}")
+                ok(f"cosign {index_name} PEP 740: {path.name} ({artifact_hash})")
                 info(f"  publisher: {publisher.get('repository', '?')}")
                 info(f"  workflow: {publisher.get('workflow', '?')}")
                 info(f"  environment: {publisher.get('environment', '?')}")

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -238,10 +238,14 @@ def verify_sigstore(path: Path, bundle: Path | None, version: str) -> bool:
         "--bundle", str(bundle),
         str(path),
     ])
+    artifact_hash = sha256(path)
     if result.returncode != 0:
-        fail(f"sigstore verify: {result.stderr.strip()}")
+        fail(f"sigstore verify: {path.name}")
+        fail(f"  artifact: {artifact_hash}")
+        if result.stderr:
+            fail(f"  error: {result.stderr.strip().splitlines()[-1]}")
         return False
-    ok(f"sigstore verify: {path.name}")
+    ok(f"sigstore verify: {path.name} ({artifact_hash})")
     return True
 
 
@@ -249,11 +253,15 @@ def verify_sigstore(path: Path, bundle: Path | None, version: str) -> bool:
 
 
 def verify_gh_attestation(path: Path) -> dict | None:
+    artifact_hash = sha256(path)
     result = run(["gh", "attestation", "verify", str(path), "--repo", REPO_SLUG, "--format", "json"])
     if result.returncode != 0:
-        fail(f"gh attestation verify: {result.stderr.strip()}")
+        fail(f"gh attestation verify: {path.name}")
+        fail(f"  artifact: {artifact_hash}")
+        if result.stderr:
+            fail(f"  error: {result.stderr.strip().splitlines()[-1]}")
         return None
-    ok(f"gh attestation verify: {path.name}")
+    ok(f"gh attestation verify: {path.name} ({artifact_hash})")
     try:
         records = json.loads(result.stdout)
         if isinstance(records, list) and records:
@@ -348,10 +356,14 @@ def verify_slsa_provenance(artifact: Path, provenance: Path, version: str) -> bo
         "--print-provenance",
         str(artifact),
     ])
+    artifact_hash = sha256(artifact)
     if result.returncode != 0:
-        fail(f"slsa-verifier: {result.stderr.strip()}")
+        fail(f"slsa-verifier: {artifact.name}")
+        fail(f"  artifact: {artifact_hash}")
+        if result.stderr:
+            fail(f"  error: {result.stderr.strip().splitlines()[-1]}")
         return False
-    ok(f"slsa-verifier: {artifact.name}")
+    ok(f"slsa-verifier: {artifact.name} ({artifact_hash})")
 
     for line in result.stdout.splitlines():
         try:
@@ -459,12 +471,14 @@ def verify_pypi_attestation(
 
         for att_data in attestations:
             att = Attestation.model_validate(att_data)
+            artifact_hash = sha256(path)
             try:
                 predicate_type, predicate = att.verify(publisher, dist)
-                ok(f"{index_name}: cryptographic verification PASSED for {path.name}")
+                ok(f"{index_name}: {path.name} ({artifact_hash})")
             except Exception as exc:  # noqa: BLE001
-                fail(f"{index_name}: cryptographic verification FAILED for {path.name}")
-                fail(f"  {exc}")
+                fail(f"{index_name}: {path.name}")
+                fail(f"  artifact: {artifact_hash}")
+                fail(f"  error: {exc}")
                 all_ok = False
                 predicate_type = "?"
                 continue

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -158,11 +158,13 @@ def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
         identity = policy.Identity(identity=identity_str, issuer=OIDC_ISSUER)
         verifier.verify_artifact(path.read_bytes(), bundle, identity)
     except Exception as exc:  # noqa: BLE001
+        artifact_hash = sha256(path)
         fail(f"sigstore verify: {path.name}")
-        fail(f"  {exc}")
+        fail(f"  artifact: {artifact_hash}")
+        fail(f"  error: {exc}")
         return False
 
-    ok(f"sigstore verify: {path.name}")
+    ok(f"sigstore verify: {path.name} ({sha256(path)})")
 
     # Extract certificate details for display
     try:
@@ -226,7 +228,7 @@ def verify_slsa_provenance(path: Path, provenance_path: Path, version: str) -> b
         fail(f"SLSA L3 provenance: could not verify subject match: {exc}")
         return False
 
-    ok(f"SLSA L3 provenance verified: {path.name}")
+    ok(f"SLSA L3 provenance verified: {path.name} ({artifact_hash})")
 
     # Decode and display provenance details
     try:
@@ -305,11 +307,14 @@ def verify_pypi_attestation(path: Path, provenance: dict, index_name: str) -> bo
 
         for att_data in bundle.get("attestations", []):
             att = Attestation.model_validate(att_data)
+            artifact_hash = sha256(path)
             try:
                 predicate_type, _ = att.verify(publisher, dist)
-                ok(f"{index_name}: verified {path.name}")
+                ok(f"{index_name}: {path.name} ({artifact_hash})")
             except Exception as exc:  # noqa: BLE001
-                fail(f"{index_name}: {path.name} — {exc}")
+                fail(f"{index_name}: {path.name}")
+                fail(f"  artifact: {artifact_hash}")
+                fail(f"  error: {exc}")
                 all_ok = False
                 continue
 
@@ -428,12 +433,13 @@ def main() -> int:
             stmt = json.loads(base64.b64decode(dsse["payload"]))
             subject_hashes = {s["digest"]["sha256"] for s in stmt.get("subject", [])}
             if artifact_hash not in subject_hashes:
-                fail(f"GH attestation: {name} — artifact hash not in subjects")
+                fail(f"GH attestation: {name}")
                 fail(f"  artifact: {artifact_hash}")
+                fail(f"  expected: {subject_hashes}")
                 failures += 1
                 continue
 
-            ok(f"GH attestation verified: {name}")
+            ok(f"GH attestation verified: {name} ({artifact_hash})")
         except Exception as exc:  # noqa: BLE001
             fail(f"GH attestation: {name} — {exc}")
             failures += 1


### PR DESCRIPTION
## Summary

Consistent output format across all five providers in all three scripts:

**On success:** `OK <provider>: <filename> (<full_hash>)`
**On failure:** `FAIL <provider>: <filename>` + `artifact: <hash>` + `error/expected: <details>`

Tested on both valid and tampered files — all providers show hashes uniformly.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)