### PR TITLE
fix: packaging changelog dates and RPM ordering

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -6,14 +6,14 @@ geek42 (0.4.2~a7-1) unstable; urgency=medium
   * Versioned proof filenames.
   * See CHANGELOG.md for details.
 
- -- Ivan Anishchuk <ivan@agorism.org>  Fri, 11 Apr 2026 00:00:00 +0000
+ -- Ivan Anishchuk <ivan@agorism.org>  Sat, 11 Apr 2026 00:00:00 +0000
 
 geek42 (0.4.1-1) unstable; urgency=medium
 
   * Fix release workflow, re-enable attestations.
   * See CHANGELOG.md for details.
 
- -- Ivan Anishchuk <ivan@agorism.org>  Fri, 11 Apr 2026 00:00:00 +0000
+ -- Ivan Anishchuk <ivan@agorism.org>  Sat, 11 Apr 2026 00:00:00 +0000
 
 geek42 (0.4.0-1) unstable; urgency=medium
 

--- a/packaging/rpm/geek42.spec
+++ b/packaging/rpm/geek42.spec
@@ -53,28 +53,16 @@ Summary:        %{summary}
 %{_bindir}/geek42
 
 %changelog
+* Sat Apr 11 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.2~a7-1
+- Pre-release: SLSA L3 provenance, PEP 740 attestations, versioned proofs.
+
+* Sat Apr 11 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.1-1
+- Fix release workflow, re-enable attestations.
+
 * Fri Apr 10 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.0-1
 - New upstream release.
 - Adds commit/push/sign/verify/deploy-status commands.
 - Full newsrepo scaffold with gemato Manifests.
-
-* Fri Apr 10 2026 Ivan Anishchuk <ivan@agorism.org> - 0.3.0-1
-- New upstream release.
-- Adds --directory / -C option to all commands.
-
-* Thu Apr 09 2026 Ivan Anishchuk <ivan@agorism.org> - 0.2.0-1
-- New upstream release.
-- Adds compose/revise/read-new commands.
-- Full supply-chain security hardening.
-
-* Fri Apr 11 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.2~a7-1
-- Pre-release: SLSA L3 provenance, PEP 740 attestations, versioned proofs.
-
-* Fri Apr 11 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.1-1
-- Fix release workflow, re-enable attestations.
-
-* Fri Apr 10 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.0-1
-- New upstream release with commit/push/sign/verify/deploy-status commands.
 
 * Fri Apr 10 2026 Ivan Anishchuk <ivan@agorism.org> - 0.3.0-1
 - Adds --directory / -C option to all commands.


### PR DESCRIPTION
## Summary

- Fix day-of-week: 2026-04-11 is Saturday, not Friday (debian + rpm)
- Remove duplicate entries in RPM changelog
- Reorder RPM changelog newest-first

From Copilot review on PR #38 (tracked in #45).

## Test plan

- [x] pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)