### PR TITLE
feat: pypi-attestations CLI, refactor verify scripts

### DIFF
--- a/docs/attestation-verification.md
+++ b/docs/attestation-verification.md
@@ -21,9 +21,9 @@ providers are verified by each script using different toolchains:
 
 | Script | Dependencies | Best for |
 |--------|-------------|----------|
-| `verify_provenance.py` | gh, sigstore CLI, slsa-verifier, pypi-attestations | Most verbose, original tools |
-| `verify_cosign.py` | cosign, gh (for proof download) | Single verification binary |
-| `verify_pure.py` | sigstore + pypi-attestations (Python), gh (for proof download) | Minimal external tools |
+| `verify_provenance.py` | gh, sigstore CLI, slsa-verifier, pypi-attestations CLI | Most verbose, each tool native |
+| `verify_cosign.py` | cosign, pypi-attestations CLI (inspect only), gh (for proof download) | Single verification binary |
+| `verify_pure.py` | sigstore + pypi-attestations (Python library), gh (for proof download) | Minimal external tools |
 
 `gh` is required by all scripts for downloading proof files.
 `verify_provenance.py` also uses `gh attestation verify` during verification.
@@ -32,7 +32,7 @@ are not already in `proofs/github/` (e.g., from `download_release.py`).
 
 **Quick start:**
 ```sh
-# Download release artifacts + proof files
+# Download release artifacts + all proof files (GitHub, PyPI, TestPyPI)
 uv run python scripts/download_release.py 0.4.2a7
 
 # Verify with any of the three scripts
@@ -40,6 +40,12 @@ uv run python scripts/verify_provenance.py 0.4.2a7
 uv run python scripts/verify_cosign.py 0.4.2a7
 uv run python scripts/verify_pure.py 0.4.2a7
 ```
+
+`download_release.py` fetches from three sources and extracts all proof formats:
+- GitHub Release assets (sigstore bundles, SLSA provenance, checksums)
+- GitHub Attestation API (build attestations + extracted sigstore bundles)
+- PyPI/TestPyPI Integrity API (PEP 740 provenance + extracted `.publish.attestation`
+  files and cosign-compatible bundles)
 
 ### Key finding: bundle format interoperability
 
@@ -91,6 +97,13 @@ slsa-verifier verify-artifact \
   --provenance-path proofs/github/geek42-v0.4.2a7-provenance.intoto.jsonl \
   --source-uri github.com/IvanAnishchuk/geek42 \
   --source-tag v0.4.2a7 \
+  dist/geek42-0.4.2a7-py3-none-any.whl
+
+# PyPI PEP 740 attestation (pypi-attestations CLI)
+# Requires .publish.attestation file — created by download_release.py
+pypi-attestations inspect dist/geek42-0.4.2a7-py3-none-any.whl.publish.attestation
+pypi-attestations verify attestation \
+  --identity 'https://github.com/IvanAnishchuk/geek42/.github/workflows/release.yml@refs/tags/v0.4.2a7' \
   dist/geek42-0.4.2a7-py3-none-any.whl
 ```
 
@@ -163,8 +176,25 @@ trustcheck inspect geek42 --expected-repo https://github.com/IvanAnishchuk/geek4
 
 ### pypi-attestations
 
-Official library (Trail of Bits / PyPI) to convert between Sigstore Bundles and
-PEP 740 Attestation objects. Primarily for programmatic use.
+Official library and CLI (Trail of Bits / PyPI) for PEP 740 attestation
+verification. The CLI (v0.0.29) provides `verify attestation`, `inspect`,
+and `convert` subcommands. geek42 uses the CLI in `verify_provenance.py`
+and for `inspect` output in `verify_cosign.py`, while `verify_pure.py`
+uses the Python library API.
+
+```sh
+# Verify a PEP 740 attestation (requires .publish.attestation file next to artifact)
+pypi-attestations verify attestation \
+  --identity 'https://github.com/IvanAnishchuk/geek42/.github/workflows/release.yml@refs/tags/v0.4.2a7' \
+  dist/geek42-0.4.2a7-py3-none-any.whl
+
+# Inspect attestation details (unverified display)
+pypi-attestations inspect dist/geek42-0.4.2a7-py3-none-any.whl.publish.attestation
+```
+
+Note: The CLI is marked as experimental (v0.0.x). The `verify pypi` subcommand
+only supports production PyPI, not TestPyPI.
+
 [PyPI: pypi-attestations](https://pypi.org/project/pypi-attestations/)
 
 ### Google OSS Rebuild

--- a/docs/pypi-attestations-cli-research.md
+++ b/docs/pypi-attestations-cli-research.md
@@ -1,0 +1,129 @@
+# pypi-attestations CLI Research (Issue #36)
+
+## Installed version
+
+pypi-attestations 0.0.29 (already a dev dependency)
+
+## CLI interface
+
+Invocation: `pypi-attestations <command>` or `python -m pypi_attestations <command>`
+
+### Subcommands
+
+| Command | Purpose | Status |
+|---------|---------|--------|
+| `verify attestation` | Verify a local `.publish.attestation` file against an artifact | Works |
+| `verify pypi` | Download + verify a package directly from PyPI | Production PyPI only (no TestPyPI) |
+| `inspect` | Display attestation structure (statement, cert, tlog) | Works |
+| `convert` | Convert a Sigstore bundle into a PEP 740 attestation | Works |
+| `sign` | Sign artifacts | Not needed for verification |
+
+### verify attestation
+
+```sh
+pypi-attestations verify attestation \
+  --identity "https://github.com/IvanAnishchuk/geek42/.github/workflows/release.yml@refs/tags/v0.4.2a7" \
+  dist/geek42-0.4.2a7-py3-none-any.whl
+# OK: dist/geek42-0.4.2a7-py3-none-any.whl.publish.attestation
+```
+
+**File naming convention:** The CLI looks for `{artifact}.publish.attestation` or
+`{artifact}.slsa.attestation` adjacent to the artifact. See
+[`_cli.py:533`](https://github.com/pypi/pypi-attestations/blob/main/src/pypi_attestations/_cli.py#L533).
+
+**Identity:** The `--identity` value must match the certificate SAN — the full
+workflow URI including ref (e.g., `@refs/tags/v0.4.2a7`).
+
+### inspect
+
+```sh
+pypi-attestations inspect dist/geek42-0.4.2a7-py3-none-any.whl.publish.attestation
+pypi-attestations inspect --dump-bytes dist/geek42-0.4.2a7-py3-none-any.whl.publish.attestation
+```
+
+Output includes:
+- Statement type and predicate type
+- Subject name and digest
+- Certificate SAN (suitable for `--identity`)
+- Certificate issuer and validity
+- Transparency log index
+
+### verify pypi
+
+```sh
+pypi-attestations verify pypi \
+  --repository https://github.com/IvanAnishchuk/geek42 \
+  pypi:geek42-0.4.2a7-py3-none-any.whl
+```
+
+**Limitation:** Hardcoded to `files.pythonhosted.org` — rejects
+`test.files.pythonhosted.org`. Not usable for TestPyPI releases.
+
+## Key discovery: format mismatch
+
+PyPI Integrity API returns a **provenance wrapper**:
+
+```json
+{
+  "attestation_bundles": [
+    {
+      "publisher": {"kind": "GitHub", "repository": "...", "workflow": "..."},
+      "attestations": [
+        {"envelope": {...}, "verification_material": {...}, "version": 1}
+      ]
+    }
+  ],
+  "version": 1
+}
+```
+
+The CLI expects individual PEP 740 `Attestation` objects (just the inner dict
+with `envelope`, `verification_material`, `version` at top level).
+
+**Extraction required:**
+
+```python
+import json
+provenance = json.load(open("provenance.json"))
+attestation = provenance["attestation_bundles"][0]["attestations"][0]
+json.dump(attestation, open("artifact.publish.attestation", "w"))
+```
+
+## Stability warning
+
+The pypi-attestations README states:
+
+> The pypi-attestations CLI is intended primarily for experimentation,
+> and is not considered a stable interface for generating or verifying
+> attestations.
+
+The version (0.0.x) reinforces this. However, for `verify_provenance.py`
+(which already shells out to multiple CLI tools), this is acceptable —
+the script is a verification demo, not a production installer.
+
+## Other tools evaluated
+
+| Tool | PEP 740 native? | CLI? | Stable? | Verdict |
+|------|-----------------|------|---------|---------|
+| `pypi-attestations` | Yes | Yes | No (0.0.x) | Best option for CLI approach |
+| `trustcheck` | Yes | Yes | No (beta, 18 stars) | Too immature |
+| `sigstore` CLI | No (bundles only) | Yes | Yes | Needs PEP 740 → bundle conversion |
+| `cosign` | No (bundles only) | Yes | Yes | Same — needs conversion (verify_cosign.py does this) |
+| `pip-plugin-pep740` | Yes | Transparent | No (5 stars) | Not ready |
+| `uv` attestation | Planned | Planned | N/A | Tracked in astral-sh/uv#9122 |
+
+## Conclusions
+
+1. **`pypi-attestations` CLI is the only tool that can verify PEP 740
+   attestations natively from the command line.** It's experimental but
+   functional and already in our dependency tree.
+
+2. **The extraction step** (provenance wrapper → individual attestation)
+   should happen during proof download, making attestation files available
+   for both CLI verification and manual inspection.
+
+3. **`inspect` is valuable** for showing attestation details without
+   needing to parse JSON manually — useful across all verify scripts.
+
+4. **`verify_pure.py` should keep the Python library approach** — it
+   exercises a different code path and doesn't need CLI subprocess calls.

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -1,8 +1,15 @@
-"""Download a geek42 release from GitHub to dist/.
+"""Download a geek42 release and all proof artifacts.
 
-Downloads wheel, sdist, and proof files (sigstore bundles, SBOM,
-checksums, SLSA provenance) from a GitHub Release. Distribution
-files go to dist/, proof files to proofs/github/.
+Downloads from three sources:
+1. GitHub Release — wheel, sdist, sigstore bundles, SBOM, checksums,
+   SLSA provenance → dist/ and proofs/github/
+2. GitHub Attestation API — build attestations → proofs/github/
+3. PyPI / TestPyPI Integrity API — PEP 740 provenance → proofs/pypi/
+
+Extracted proof files ready for all three verify scripts:
+- *.publish.attestation  — for pypi-attestations CLI (verify_provenance.py)
+- *.cosign-bundle.json   — for cosign (verify_cosign.py)
+- *.gh-attestation-bundle.json — for cosign (verify_cosign.py)
 
 Usage:
     uv run python scripts/download_release.py [VERSION]
@@ -12,17 +19,47 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 import sys
+import tomllib
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-REPO_SLUG = "IvanAnishchuk/geek42"
+DIST_EXTENSIONS = (".whl", ".tar.gz")
+
+# Known CI providers and their OIDC issuers
+KNOWN_HOSTS = {
+    "github.com": "https://token.actions.githubusercontent.com",
+}
+
+# -- Trust anchors (derived from pyproject.toml) ---------------------------
+
+_pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+PACKAGE_NAME = _pyproject["project"]["name"]
+_repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
+_repo_host = _repo_url.hostname
+if _repo_host not in KNOWN_HOSTS:
+    print(f"Error: Unknown repository host: {_repo_host}")
+    print(f"Known hosts: {', '.join(KNOWN_HOSTS)}")
+    sys.exit(1)
+REPO_SLUG = _repo_url.path.strip("/")
+
+# Release conventions — update these if your project uses different values
+TAG_PREFIX = "v"  # tags are formatted as v{version}, e.g. v0.4.2a7
+
 DIST_DIR = REPO_ROOT / "dist"
 PROOFS_DIR = REPO_ROOT / "proofs" / "github"
+PYPI_PROOFS_DIR = REPO_ROOT / "proofs" / "pypi"
 
-DIST_EXTENSIONS = (".whl", ".tar.gz")
+PYPI_INDEXES = [
+    ("PyPI", "https://pypi.org"),
+    ("TestPyPI", "https://test.pypi.org"),
+]
 
 
 def get_version() -> str:
@@ -36,18 +73,22 @@ def get_version() -> str:
     sys.exit(1)
 
 
-def main() -> int:
-    version = get_version()
-    tag = f"v{version}"
+def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)  # noqa: S603 — args are list literals, no shell
 
-    DIST_DIR.mkdir(exist_ok=True)
-    PROOFS_DIR.mkdir(parents=True, exist_ok=True)
 
-    print(f"Downloading {tag} from {REPO_SLUG}...")
+def is_dist_file(name: str) -> bool:
+    return any(name.endswith(ext) for ext in DIST_EXTENSIONS)
 
-    # Download everything to a single temp location, then sort
+
+# -- GitHub Release --------------------------------------------------------
+
+
+def download_github_release(version: str) -> bool:
+    """Download all assets from a GitHub Release."""
+    tag = f"{TAG_PREFIX}{version}"
     gh = shutil.which("gh") or "gh"
-    result = subprocess.run(  # noqa: S603 — args are list literals, no shell
+    result = run(
         [
             gh,
             "release",
@@ -58,39 +99,191 @@ def main() -> int:
             "--dir",
             str(DIST_DIR),
             "--skip-existing",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
+        ]
     )
     if result.returncode != 0:
         print(f"Error: GitHub Release {tag} not found")
         if result.stderr:
             print(f"  {result.stderr.strip()}")
-        return 1
+        return False
 
     # Move non-distribution files to proofs/github/
-    moved = 0
     for f in sorted(DIST_DIR.iterdir()):
-        if not any(f.name.endswith(ext) for ext in DIST_EXTENSIONS):
+        if not is_dist_file(f.name):
             target = PROOFS_DIR / f.name
             if not target.exists():
                 f.rename(target)
-                moved += 1
             else:
                 f.unlink()  # duplicate, already in proofs
+    return True
 
+
+# -- GitHub Attestations ---------------------------------------------------
+
+
+def fetch_gh_attestations(version: str) -> None:
+    """Fetch and extract GitHub attestation bundles for each dist file."""
+    gh = shutil.which("gh") or "gh"
+    for f in sorted(DIST_DIR.iterdir()):
+        if not is_dist_file(f.name):
+            continue
+        att_file = PROOFS_DIR / f"{f.name}.gh-attestation.json"
+        if att_file.exists():
+            continue
+
+        result = run(
+            [
+                gh,
+                "attestation",
+                "verify",
+                str(f),
+                "--repo",
+                REPO_SLUG,
+                "--format",
+                "json",
+            ]
+        )
+        if result.returncode != 0:
+            print(f"  gh attestation: {f.name} — not available")
+            continue
+
+        try:
+            records = json.loads(result.stdout)
+            if isinstance(records, list) and records:
+                att_file.write_text(json.dumps(records, indent=2))
+                print(f"  gh attestation: {f.name} — saved")
+
+                # Extract inner sigstore bundle for cosign
+                bundle_json = json.dumps(records[0]["attestation"]["bundle"])
+                bundle_file = PROOFS_DIR / f"{f.name}.gh-attestation-bundle.json"
+                bundle_file.write_text(bundle_json)
+                print(f"  gh attestation bundle: {f.name} — extracted")
+        except (json.JSONDecodeError, KeyError) as exc:
+            print(f"  gh attestation: {f.name} — parse error: {exc}")
+
+
+# -- PyPI / TestPyPI Provenance --------------------------------------------
+
+
+def fetch_pypi_provenance(
+    package: str,
+    version: str,
+    filename: str,
+    base_url: str,
+) -> dict | None:
+    """Fetch provenance from PyPI Integrity API."""
+    url = f"{base_url}/integrity/{package}/{version}/{filename}/provenance"
+    if not url.startswith(("https://pypi.org/", "https://test.pypi.org/")):
+        return None
+    try:
+        req = urllib.request.Request(url)  # noqa: S310 — URL validated above
+        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
+            return json.loads(resp.read())
+    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError):
+        return None
+
+
+def extract_pypi_proofs(version: str) -> None:
+    """Fetch PyPI/TestPyPI provenance and extract all proof formats."""
+    for index_name, base_url in PYPI_INDEXES:
+        for f in sorted(DIST_DIR.iterdir()):
+            if not is_dist_file(f.name):
+                continue
+
+            prov = fetch_pypi_provenance(PACKAGE_NAME, version, f.name, base_url)
+            if not prov:
+                print(f"  {index_name}: {f.name} — no attestation")
+                continue
+
+            # Save raw provenance
+            suffix = "testpypi-provenance" if index_name == "TestPyPI" else "provenance"
+            prov_file = PYPI_PROOFS_DIR / f"{f.name}.{suffix}.json"
+            prov_file.write_text(json.dumps(prov, indent=2))
+            print(f"  {index_name}: {f.name} — provenance saved")
+
+            bundles = prov.get("attestation_bundles", [])
+            if not bundles:
+                continue
+
+            for bundle_data in bundles:
+                attestations = bundle_data.get("attestations", [])
+                if not attestations:
+                    continue
+                att = attestations[0]
+
+                # Extract individual PEP 740 attestation for pypi-attestations CLI
+                att_suffix = "testpypi" if index_name == "TestPyPI" else "pypi"
+                att_file = PYPI_PROOFS_DIR / f"{f.name}.{att_suffix}-attestation.json"
+                att_file.write_text(json.dumps(att))
+                # Also place in dist/ for pypi-attestations CLI discovery
+                dist_att = DIST_DIR / f"{f.name}.publish.attestation"
+                dist_att.write_text(json.dumps(att))
+                print(f"  {index_name}: {f.name} — .publish.attestation extracted")
+
+                # Restructure into cosign-compatible bundle
+                vm = att.get("verification_material", {})
+                cosign_bundle = {
+                    "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+                    "verificationMaterial": {
+                        "certificate": {"rawBytes": vm["certificate"]},
+                        "tlogEntries": vm["transparency_entries"],
+                        "timestampVerificationData": {},
+                    },
+                    "dsseEnvelope": {
+                        "payload": att["envelope"]["statement"],
+                        "payloadType": "application/vnd.in-toto+json",
+                        "signatures": [{"sig": att["envelope"]["signature"]}],
+                    },
+                }
+                cosign_suffix = (
+                    "testpypi-cosign-bundle" if index_name == "TestPyPI" else "cosign-bundle"
+                )
+                cosign_file = PYPI_PROOFS_DIR / f"{f.name}.{cosign_suffix}.json"
+                cosign_file.write_text(json.dumps(cosign_bundle, indent=2))
+                print(f"  {index_name}: {f.name} — cosign bundle extracted")
+
+
+# -- Main ------------------------------------------------------------------
+
+
+def main() -> int:
+    version = get_version()
+    tag = f"{TAG_PREFIX}{version}"
+
+    DIST_DIR.mkdir(exist_ok=True)
+    PROOFS_DIR.mkdir(parents=True, exist_ok=True)
+    PYPI_PROOFS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # 1. GitHub Release
+    print(f"Downloading {tag} from {REPO_SLUG}...")
+    if not download_github_release(version):
+        return 1
+
+    # 2. GitHub Attestations
+    print("\nFetching GitHub attestations...")
+    fetch_gh_attestations(version)
+
+    # 3. PyPI / TestPyPI provenance + extraction
+    print("\nFetching PyPI/TestPyPI provenance...")
+    extract_pypi_proofs(version)
+
+    # Summary
     dist_files = [f for f in sorted(DIST_DIR.iterdir()) if f.is_file()]
-    proof_files = [
-        f for f in sorted(PROOFS_DIR.iterdir()) if f.is_file() and f.name != ".gitignore"
+    gh_files = [f for f in sorted(PROOFS_DIR.iterdir()) if f.is_file() and f.name != ".gitignore"]
+    pypi_files = [
+        f for f in sorted(PYPI_PROOFS_DIR.iterdir()) if f.is_file() and f.name != ".gitignore"
     ]
 
     print(f"\ndist/ ({len(dist_files)} files):")
     for f in dist_files:
         print(f"  {f.name}")
 
-    print(f"\nproofs/github/ ({len(proof_files)} files):")
-    for f in proof_files:
+    print(f"\nproofs/github/ ({len(gh_files)} files):")
+    for f in gh_files:
+        print(f"  {f.name}")
+
+    print(f"\nproofs/pypi/ ({len(pypi_files)} files):")
+    for f in pypi_files:
         print(f"  {f.name}")
 
     print(f"\nVerify with: uv run python scripts/verify_provenance.py {version}")

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -54,11 +54,10 @@ TAG_PREFIX = "v"  # tags are formatted as v{version}, e.g. v0.4.2a7
 
 DIST_DIR = REPO_ROOT / "dist"
 PROOFS_DIR = REPO_ROOT / "proofs" / "github"
-PYPI_PROOFS_DIR = REPO_ROOT / "proofs" / "pypi"
 
 PYPI_INDEXES = [
-    ("PyPI", "https://pypi.org"),
-    ("TestPyPI", "https://test.pypi.org"),
+    ("pypi", "https://pypi.org"),
+    ("testpypi", "https://test.pypi.org"),
 ]
 
 
@@ -184,8 +183,14 @@ def fetch_pypi_provenance(
 
 
 def extract_pypi_proofs(version: str) -> None:
-    """Fetch PyPI/TestPyPI provenance and extract all proof formats."""
+    """Fetch PyPI/TestPyPI provenance and extract all proof formats.
+
+    Each index gets its own directory: proofs/pypi/, proofs/testpypi/.
+    """
     for index_name, base_url in PYPI_INDEXES:
+        proofs_dir = REPO_ROOT / "proofs" / index_name
+        proofs_dir.mkdir(parents=True, exist_ok=True)
+
         for f in sorted(DIST_DIR.iterdir()):
             if not is_dist_file(f.name):
                 continue
@@ -196,8 +201,7 @@ def extract_pypi_proofs(version: str) -> None:
                 continue
 
             # Save raw provenance
-            suffix = "testpypi-provenance" if index_name == "TestPyPI" else "provenance"
-            prov_file = PYPI_PROOFS_DIR / f"{f.name}.{suffix}.json"
+            prov_file = proofs_dir / f"{f.name}.provenance.json"
             prov_file.write_text(json.dumps(prov, indent=2))
             print(f"  {index_name}: {f.name} — provenance saved")
 
@@ -212,12 +216,8 @@ def extract_pypi_proofs(version: str) -> None:
                 att = attestations[0]
 
                 # Extract individual PEP 740 attestation for pypi-attestations CLI
-                att_suffix = "testpypi" if index_name == "TestPyPI" else "pypi"
-                att_file = PYPI_PROOFS_DIR / f"{f.name}.{att_suffix}-attestation.json"
+                att_file = proofs_dir / f"{f.name}.publish.attestation"
                 att_file.write_text(json.dumps(att))
-                # Also place in dist/ for pypi-attestations CLI discovery
-                dist_att = DIST_DIR / f"{f.name}.publish.attestation"
-                dist_att.write_text(json.dumps(att))
                 print(f"  {index_name}: {f.name} — .publish.attestation extracted")
 
                 # Restructure into cosign-compatible bundle
@@ -235,10 +235,7 @@ def extract_pypi_proofs(version: str) -> None:
                         "signatures": [{"sig": att["envelope"]["signature"]}],
                     },
                 }
-                cosign_suffix = (
-                    "testpypi-cosign-bundle" if index_name == "TestPyPI" else "cosign-bundle"
-                )
-                cosign_file = PYPI_PROOFS_DIR / f"{f.name}.{cosign_suffix}.json"
+                cosign_file = proofs_dir / f"{f.name}.cosign-bundle.json"
                 cosign_file.write_text(json.dumps(cosign_bundle, indent=2))
                 print(f"  {index_name}: {f.name} — cosign bundle extracted")
 
@@ -252,7 +249,6 @@ def main() -> int:
 
     DIST_DIR.mkdir(exist_ok=True)
     PROOFS_DIR.mkdir(parents=True, exist_ok=True)
-    PYPI_PROOFS_DIR.mkdir(parents=True, exist_ok=True)
 
     # 1. GitHub Release
     print(f"Downloading {tag} from {REPO_SLUG}...")
@@ -270,9 +266,6 @@ def main() -> int:
     # Summary
     dist_files = [f for f in sorted(DIST_DIR.iterdir()) if f.is_file()]
     gh_files = [f for f in sorted(PROOFS_DIR.iterdir()) if f.is_file() and f.name != ".gitignore"]
-    pypi_files = [
-        f for f in sorted(PYPI_PROOFS_DIR.iterdir()) if f.is_file() and f.name != ".gitignore"
-    ]
 
     print(f"\ndist/ ({len(dist_files)} files):")
     for f in dist_files:
@@ -282,9 +275,15 @@ def main() -> int:
     for f in gh_files:
         print(f"  {f.name}")
 
-    print(f"\nproofs/pypi/ ({len(pypi_files)} files):")
-    for f in pypi_files:
-        print(f"  {f.name}")
+    for index_name, _base_url in PYPI_INDEXES:
+        proofs_dir = REPO_ROOT / "proofs" / index_name
+        if proofs_dir.is_dir():
+            files = [
+                f for f in sorted(proofs_dir.iterdir()) if f.is_file() and f.name != ".gitignore"
+            ]
+            print(f"\nproofs/{index_name}/ ({len(files)} files):")
+            for f in files:
+                print(f"  {f.name}")
 
     print(f"\nVerify with: uv run python scripts/verify_provenance.py {version}")
     return 0

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -30,7 +30,9 @@ import hashlib
 import json
 import subprocess
 import sys
+import tomllib
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -40,12 +42,30 @@ from rich.panel import Panel
 console = Console()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-REPO_OWNER = "IvanAnishchuk"
-REPO_NAME = "geek42"
-REPO_SLUG = f"{REPO_OWNER}/{REPO_NAME}"
-PACKAGE_NAME = "geek42"
 DIST_EXTENSIONS = (".whl", ".tar.gz")
-OIDC_ISSUER = "https://token.actions.githubusercontent.com"
+
+# Known CI providers and their OIDC issuers
+KNOWN_HOSTS = {
+    "github.com": "https://token.actions.githubusercontent.com",
+}
+
+# -- Trust anchors (derived from pyproject.toml) ---------------------------
+
+_pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+PACKAGE_NAME = _pyproject["project"]["name"]
+_repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
+_repo_host = _repo_url.hostname
+if _repo_host not in KNOWN_HOSTS:
+    console.print(f"[bold red]Unknown repository host: {_repo_host}[/]")
+    console.print(f"[dim]Known hosts: {', '.join(KNOWN_HOSTS)}[/]")
+    sys.exit(1)
+REPO_SLUG = _repo_url.path.strip("/")
+OIDC_ISSUER = KNOWN_HOSTS[_repo_host]
+
+# Release conventions — update these if your project uses different values
+RELEASE_WORKFLOW = "release.yml"
+TAG_PREFIX = "v"  # tags are formatted as v{version}, e.g. v0.4.2a7
+
 PYPI_INDEXES = [
     ("PyPI", "https://pypi.org"),
     ("TestPyPI", "https://test.pypi.org"),
@@ -115,7 +135,7 @@ def verify_sigstore_blob(path: Path, bundle: Path, version: str) -> bool:
         return True  # not a failure, just not available
 
     # Use exact identity for the specific tag
-    identity = f"https://github.com/{REPO_SLUG}/.github/workflows/release.yml@refs/tags/v{version}"
+    identity = f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
 
     result = run(
         [
@@ -196,29 +216,28 @@ def verify_slsa_attestation(path: Path, provenance: Path) -> bool:
     return True
 
 
-def verify_gh_attestation(path: Path, att_file: Path, version: str) -> bool:
-    """Verify GitHub attestation by extracting the sigstore bundle and using cosign."""
-    if not att_file.exists():
-        info(f"No GH attestation file for {path.name}")
-        return True
+def verify_gh_attestation(path: Path, gh_proofs: Path, version: str) -> bool:
+    """Verify GitHub attestation using pre-extracted or inline-extracted bundle."""
+    bundle_file = gh_proofs / f"{path.name}.gh-attestation-bundle.json"
 
-    try:
-        data = json.loads(att_file.read_text())
-        if not isinstance(data, list) or not data:
-            info(f"Empty or invalid GH attestation for {path.name}")
+    # If pre-extracted bundle doesn't exist, try extracting from attestation JSON
+    if not bundle_file.exists():
+        att_file = gh_proofs / f"{path.name}.gh-attestation.json"
+        if not att_file.exists():
+            info(f"No GH attestation file for {path.name}")
             return True
-        bundle_json = json.dumps(data[0]["attestation"]["bundle"])
-    except (json.JSONDecodeError, KeyError) as exc:
-        fail(f"Could not parse GH attestation: {exc}")
-        return False
+        try:
+            data = json.loads(att_file.read_text())
+            if not isinstance(data, list) or not data:
+                info(f"Empty or invalid GH attestation for {path.name}")
+                return True
+            bundle_json = json.dumps(data[0]["attestation"]["bundle"])
+            bundle_file.write_text(bundle_json)
+        except (json.JSONDecodeError, KeyError) as exc:
+            fail(f"Could not parse GH attestation: {exc}")
+            return False
 
-    # Save extracted bundle to proofs/ for inspection
-    proofs = REPO_ROOT / "proofs" / "github"
-    proofs.mkdir(parents=True, exist_ok=True)
-    extracted = proofs / f"{path.name}.gh-attestation-bundle.json"
-    extracted.write_text(bundle_json)
-
-    identity = f"https://github.com/{REPO_SLUG}/.github/workflows/release.yml@refs/tags/v{version}"
+    identity = f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
     result = run(
         [
             "cosign",
@@ -230,7 +249,7 @@ def verify_gh_attestation(path: Path, att_file: Path, version: str) -> bool:
             "--type",
             "slsaprovenance",
             "--bundle",
-            str(extracted),
+            str(bundle_file),
             str(path),
         ]
     )
@@ -265,8 +284,33 @@ def fetch_pypi_provenance(
         return None
 
 
-def verify_pypi_attestation(path: Path, provenance: dict, index_name: str) -> bool:
-    """Verify PyPI PEP 740 attestation by restructuring into a cosign-compatible bundle."""
+def _restructure_pep740_to_cosign(att: dict) -> dict:
+    """Restructure a PEP 740 attestation into a cosign-compatible sigstore bundle."""
+    vm = att.get("verification_material", {})
+    return {
+        "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+        "verificationMaterial": {
+            "certificate": {"rawBytes": vm["certificate"]},
+            "tlogEntries": vm["transparency_entries"],
+            "timestampVerificationData": {},
+        },
+        "dsseEnvelope": {
+            "payload": att["envelope"]["statement"],
+            "payloadType": "application/vnd.in-toto+json",
+            "signatures": [{"sig": att["envelope"]["signature"]}],
+        },
+    }
+
+
+def verify_pypi_attestation(
+    path: Path,
+    provenance: dict,
+    index_name: str,
+) -> bool:
+    """Verify PyPI PEP 740 attestation using cosign + pypi-attestations inspect."""
+    pypi_proofs = REPO_ROOT / "proofs" / "pypi"
+    pypi_proofs.mkdir(parents=True, exist_ok=True)
+
     bundles = provenance.get("attestation_bundles", [])
     if not bundles:
         fail(f"No attestation bundles in {index_name} provenance")
@@ -274,28 +318,23 @@ def verify_pypi_attestation(path: Path, provenance: dict, index_name: str) -> bo
 
     all_ok = True
     for bundle_data in bundles:
-        for att in bundle_data.get("attestations", []):
-            vm = att.get("verification_material", {})
-            # Restructure PEP 740 format into a sigstore bundle cosign understands
-            cosign_bundle = {
-                "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
-                "verificationMaterial": {
-                    "certificate": {"rawBytes": vm["certificate"]},
-                    "tlogEntries": vm["transparency_entries"],
-                    "timestampVerificationData": {},
-                },
-                "dsseEnvelope": {
-                    "payload": att["envelope"]["statement"],
-                    "payloadType": "application/vnd.in-toto+json",
-                    "signatures": [{"sig": att["envelope"]["signature"]}],
-                },
-            }
+        publisher = bundle_data.get("publisher", {})
 
-            # Save restructured bundle to proofs/pypi/ for inspection
-            pypi_proofs = REPO_ROOT / "proofs" / "pypi"
-            pypi_proofs.mkdir(parents=True, exist_ok=True)
-            extracted = pypi_proofs / f"{path.name}.{index_name.lower()}-cosign-bundle.json"
-            extracted.write_text(json.dumps(cosign_bundle, indent=2))
+        for att in bundle_data.get("attestations", []):
+            # Use pre-extracted cosign bundle or restructure inline
+            cosign_suffix = (
+                "testpypi-cosign-bundle" if index_name == "TestPyPI" else "cosign-bundle"
+            )
+            bundle_file = pypi_proofs / f"{path.name}.{cosign_suffix}.json"
+            if not bundle_file.exists():
+                cosign_bundle = _restructure_pep740_to_cosign(att)
+                bundle_file.write_text(json.dumps(cosign_bundle, indent=2))
+
+            # Also extract .publish.attestation for inspect
+            att_suffix = "testpypi" if index_name == "TestPyPI" else "pypi"
+            att_file = pypi_proofs / f"{path.name}.{att_suffix}-attestation.json"
+            if not att_file.exists():
+                att_file.write_text(json.dumps(att))
 
             result = run(
                 [
@@ -308,7 +347,7 @@ def verify_pypi_attestation(path: Path, provenance: dict, index_name: str) -> bo
                     "--type",
                     "https://docs.pypi.org/attestations/publish/v1",
                     "--bundle",
-                    str(extracted),
+                    str(bundle_file),
                     str(path),
                 ]
             )
@@ -320,13 +359,28 @@ def verify_pypi_attestation(path: Path, provenance: dict, index_name: str) -> bo
                     fail(f"  error: {result.stderr.strip().splitlines()[-1]}")
                 all_ok = False
             else:
-                publisher = bundle_data.get("publisher", {})
                 repo = publisher.get("repository", "?")
                 wf = publisher.get("workflow", "?")
                 ok(f"cosign {index_name} PEP 740: {path.name} ({artifact_hash})")
                 info(f"  signed by: {repo}/{wf}")
                 info(f"  environment: {publisher.get('environment', '?')}")
                 info(f"  trust root: {OIDC_ISSUER}")
+
+                # Show PEP 740 details with pypi-attestations inspect
+                inspect_result = run(
+                    [
+                        "uv",
+                        "run",
+                        "pypi-attestations",
+                        "inspect",
+                        str(att_file),
+                    ]
+                )
+                # inspect writes to stderr (uses rich console internally)
+                inspect_output = inspect_result.stderr or inspect_result.stdout
+                if inspect_result.returncode == 0 and inspect_output:
+                    for line in inspect_output.strip().splitlines():
+                        info(line)
 
     return all_ok
 
@@ -401,7 +455,7 @@ def main() -> int:
     if not gh_proofs.exists() or not any(gh_proofs.iterdir()):
         header("Downloading proof files")
         gh_proofs.mkdir(parents=True, exist_ok=True)
-        tag = f"v{version}"
+        tag = f"{TAG_PREFIX}{version}"
         result = run(
             [
                 "gh",
@@ -476,9 +530,8 @@ def main() -> int:
             border_style="dim",
         )
     )
-    for name, path in artifacts.items():
-        att_file = gh_proofs / f"{name}.gh-attestation.json"
-        if not verify_gh_attestation(path, att_file, version):
+    for _name, path in artifacts.items():
+        if not verify_gh_attestation(path, gh_proofs, version):
             failures += 1
 
     # -- 5. PyPI / TestPyPI attestations (cosign) ----------------------
@@ -487,8 +540,9 @@ def main() -> int:
         Panel(
             "[bold]PyPI PEP 740 attestations[/] use a different JSON format\n"
             "but contain the same sigstore primitives (certificate + Rekor\n"
-            "entry + DSSE envelope). This script restructures them into\n"
-            "cosign-compatible bundles for verification.",
+            "entry + DSSE envelope). Uses pre-extracted cosign bundles from\n"
+            "download_release.py, or restructures inline as fallback.\n"
+            "Attestation details shown via pypi-attestations inspect.",
             border_style="dim",
         )
     )

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -308,8 +308,9 @@ def verify_pypi_attestation(
     index_name: str,
 ) -> bool:
     """Verify PyPI PEP 740 attestation using cosign + pypi-attestations inspect."""
-    pypi_proofs = REPO_ROOT / "proofs" / "pypi"
-    pypi_proofs.mkdir(parents=True, exist_ok=True)
+    index_dir = "testpypi" if index_name == "TestPyPI" else "pypi"
+    proofs_dir = REPO_ROOT / "proofs" / index_dir
+    proofs_dir.mkdir(parents=True, exist_ok=True)
 
     bundles = provenance.get("attestation_bundles", [])
     if not bundles:
@@ -322,17 +323,13 @@ def verify_pypi_attestation(
 
         for att in bundle_data.get("attestations", []):
             # Use pre-extracted cosign bundle or restructure inline
-            cosign_suffix = (
-                "testpypi-cosign-bundle" if index_name == "TestPyPI" else "cosign-bundle"
-            )
-            bundle_file = pypi_proofs / f"{path.name}.{cosign_suffix}.json"
+            bundle_file = proofs_dir / f"{path.name}.cosign-bundle.json"
             if not bundle_file.exists():
                 cosign_bundle = _restructure_pep740_to_cosign(att)
                 bundle_file.write_text(json.dumps(cosign_bundle, indent=2))
 
             # Also extract .publish.attestation for inspect
-            att_suffix = "testpypi" if index_name == "TestPyPI" else "pypi"
-            att_file = pypi_proofs / f"{path.name}.{att_suffix}-attestation.json"
+            att_file = proofs_dir / f"{path.name}.publish.attestation"
             if not att_file.exists():
                 att_file.write_text(json.dumps(att))
 

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -28,8 +28,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
 import subprocess
 import sys
+import tempfile
 import tomllib
 import urllib.error
 import urllib.parse
@@ -520,16 +522,12 @@ def extract_attestation_file(
     if not attestations:
         return None
 
-    # Save next to the artifact for CLI consumption
-    att_file = path.parent / f"{path.name}.publish.attestation"
+    # Save to proofs/{index}/ directory
+    index_dir = "testpypi" if index_name == "TestPyPI" else "pypi"
+    proofs_dir = _ensure_proofs_dir() / index_dir
+    proofs_dir.mkdir(exist_ok=True)
+    att_file = proofs_dir / f"{path.name}.publish.attestation"
     att_file.write_text(json.dumps(attestations[0]))
-
-    # Also save to proofs/pypi/ for archival
-    pypi_proofs = _ensure_proofs_dir() / "pypi"
-    pypi_proofs.mkdir(exist_ok=True)
-    suffix = "testpypi" if index_name == "TestPyPI" else "pypi"
-    proof_att = pypi_proofs / f"{path.name}.{suffix}-attestation.json"
-    proof_att.write_text(json.dumps(attestations[0]))
 
     return att_file
 
@@ -570,27 +568,41 @@ def verify_pypi_attestation(
     # Inspect attestation details (unverified display)
     inspect_attestation(att_file)
 
-    # Build identity from publisher data
+    # Use local trust anchors for identity — never relax to provenance publisher data
     publisher_data = bundles[0].get("publisher", {})
-    repo = publisher_data.get("repository", REPO_SLUG)
-    workflow = publisher_data.get("workflow", RELEASE_WORKFLOW)
     identity = (
-        f"https://github.com/{repo}/.github/workflows/{workflow}@refs/tags/{TAG_PREFIX}{version}"
+        f"https://github.com/{REPO_SLUG}"
+        f"/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
     )
 
+    # Warn if publisher data doesn't match trust anchors
+    pub_repo = publisher_data.get("repository", "")
+    pub_wf = publisher_data.get("workflow", "")
+    if pub_repo and pub_repo != REPO_SLUG:
+        fail(f"Publisher repo mismatch: {pub_repo} != {REPO_SLUG}")
+    if pub_wf and pub_wf != RELEASE_WORKFLOW:
+        fail(f"Publisher workflow mismatch: {pub_wf} != {RELEASE_WORKFLOW}")
+
     # Verify with pypi-attestations CLI
-    result = run(
-        [
-            "uv",
-            "run",
-            "pypi-attestations",
-            "verify",
-            "attestation",
-            "--identity",
-            identity,
-            str(path),
-        ]
-    )
+    # CLI expects {artifact}.publish.attestation next to the artifact,
+    # so copy both into a temporary directory for verification
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        tmp_artifact = tmp / path.name
+        shutil.copy2(path, tmp_artifact)
+        shutil.copy2(att_file, tmp / f"{path.name}.publish.attestation")
+        result = run(
+            [
+                "uv",
+                "run",
+                "pypi-attestations",
+                "verify",
+                "attestation",
+                "--identity",
+                identity,
+                str(tmp_artifact),
+            ]
+        )
 
     artifact_hash = sha256(path)
     if result.returncode != 0:
@@ -602,7 +614,7 @@ def verify_pypi_attestation(
 
     ok(f"{index_name}: {path.name} ({artifact_hash})")
     info("  verified by: pypi-attestations verify attestation")
-    info(f"  signed by: {repo}/{workflow}")
+    info(f"  signed by: {pub_repo}/{pub_wf}")
     info(f"  environment: {publisher_data.get('environment', '?')}")
     info(f"  trust root: {OIDC_ISSUER}")
 
@@ -633,10 +645,10 @@ def save_provenance_to_proofs(
     filename: str,
     index_name: str,
 ) -> None:
-    pypi_proofs = _ensure_proofs_dir() / "pypi"
-    pypi_proofs.mkdir(exist_ok=True)
-    suffix = "testpypi-provenance" if index_name == "TestPyPI" else "provenance"
-    out = pypi_proofs / f"{filename}.{suffix}.json"
+    index_dir = "testpypi" if index_name == "TestPyPI" else "pypi"
+    proofs_dir = _ensure_proofs_dir() / index_dir
+    proofs_dir.mkdir(exist_ok=True)
+    out = proofs_dir / f"{filename}.provenance.json"
     out.write_text(json.dumps(provenance, indent=2))
     info(f"Saved to {out.relative_to(REPO_ROOT)}")
 

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -12,14 +12,15 @@ Files must already exist in dist/ (build with 'uv build' or download with
 'pip download'). Proof artifacts are cached in proofs/{github,pypi}/.
 
 Requirements:
-  - gh              (GitHub CLI, for attestation verify + release download)
-  - sigstore        (uv tool run sigstore, for sigstore bundle verification)
-  - slsa-verifier   (Go binary, for SLSA L3 provenance verification)
-  - rich            (Python, for pretty output — already a project dependency)
+  - gh                (GitHub CLI, for attestation verify + release download)
+  - sigstore          (uv tool run sigstore, for sigstore bundle verification)
+  - slsa-verifier     (Go binary, for SLSA L3 provenance verification)
+  - pypi-attestations (CLI, for PEP 740 attestation verify + inspect)
+  - rich              (Python, for pretty output — already a project dependency)
 
 Usage:
     uv run python scripts/verify_provenance.py [VERSION]
-    uv run python scripts/verify_provenance.py 0.4.2a5
+    uv run python scripts/verify_provenance.py 0.4.2a7
     uv run python scripts/verify_provenance.py          # auto-detects from __init__.py
 """
 
@@ -29,7 +30,9 @@ import hashlib
 import json
 import subprocess
 import sys
+import tomllib
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -40,11 +43,29 @@ from rich.table import Table
 console = Console()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-REPO_OWNER = "IvanAnishchuk"
-REPO_NAME = "geek42"
-REPO_SLUG = f"{REPO_OWNER}/{REPO_NAME}"
-PACKAGE_NAME = "geek42"
 DIST_EXTENSIONS = (".whl", ".tar.gz")
+
+# Known CI providers and their OIDC issuers
+KNOWN_HOSTS = {
+    "github.com": "https://token.actions.githubusercontent.com",
+}
+
+# -- Trust anchors (derived from pyproject.toml) ---------------------------
+
+_pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+PACKAGE_NAME = _pyproject["project"]["name"]
+_repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
+_repo_host = _repo_url.hostname
+if _repo_host not in KNOWN_HOSTS:
+    console.print(f"[bold red]Unknown repository host: {_repo_host}[/]")
+    console.print(f"[dim]Known hosts: {', '.join(KNOWN_HOSTS)}[/]")
+    sys.exit(1)
+REPO_SLUG = _repo_url.path.strip("/")
+OIDC_ISSUER = KNOWN_HOSTS[_repo_host]
+
+# Release conventions — update these if your project uses different values
+RELEASE_WORKFLOW = "release.yml"
+TAG_PREFIX = "v"  # tags are formatted as v{version}, e.g. v0.4.2a7
 
 # -- Descriptions for each mechanism ----------------------------------
 
@@ -157,7 +178,7 @@ def download_github_proofs(version: str) -> Path:
     """
     gh_proofs = _ensure_proofs_dir() / "github"
     gh_proofs.mkdir(exist_ok=True)
-    tag = f"v{version}"
+    tag = f"{TAG_PREFIX}{version}"
     result = run(
         [
             "gh",
@@ -236,7 +257,7 @@ def verify_sigstore(path: Path, bundle: Path | None, version: str) -> bool:
 
     san = _extract_san_from_bundle(bundle)
     if not san:
-        san = f"https://github.com/{REPO_SLUG}/.github/workflows/release.yml@refs/tags/v{version}"
+        san = f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
 
     result = run(
         [
@@ -249,7 +270,7 @@ def verify_sigstore(path: Path, bundle: Path | None, version: str) -> bool:
             "--cert-identity",
             san,
             "--cert-oidc-issuer",
-            "https://token.actions.githubusercontent.com",
+            OIDC_ISSUER,
             "--bundle",
             str(bundle),
             str(path),
@@ -264,7 +285,7 @@ def verify_sigstore(path: Path, bundle: Path | None, version: str) -> bool:
         return False
     ok(f"sigstore verify: {path.name} ({artifact_hash})")
     info(f"  signed by: {san}")
-    info("  trust root: https://token.actions.githubusercontent.com")
+    info(f"  trust root: {OIDC_ISSUER}")
     return True
 
 
@@ -283,7 +304,7 @@ def verify_gh_attestation(path: Path) -> dict | None:
             fail(f"  error: {result.stderr.strip().splitlines()[-1]}")
         return None
     ok(f"gh attestation verify: {path.name} ({artifact_hash})")
-    info("  trust root: https://token.actions.githubusercontent.com (via GitHub)")
+    info(f"  trust root: {OIDC_ISSUER} (via GitHub)")
     try:
         records = json.loads(result.stdout)
         if isinstance(records, list) and records:
@@ -368,7 +389,7 @@ def _find_slsa_verifier() -> str:
 
 
 def verify_slsa_provenance(artifact: Path, provenance: Path, version: str) -> bool:
-    tag = f"v{version}"
+    tag = f"{TAG_PREFIX}{version}"
     verifier = _find_slsa_verifier()
     result = run(
         [
@@ -393,7 +414,7 @@ def verify_slsa_provenance(artifact: Path, provenance: Path, version: str) -> bo
         return False
     ok(f"slsa-verifier: {artifact.name} ({artifact_hash})")
     info("  signed by: slsa-framework/slsa-github-generator@v2.1.0")
-    info("  trust root: https://token.actions.githubusercontent.com")
+    info(f"  trust root: {OIDC_ISSUER}")
 
     for line in result.stdout.splitlines():
         try:
@@ -481,74 +502,130 @@ def fetch_pypi_provenance(
         return None
 
 
+def extract_attestation_file(
+    path: Path,
+    provenance: dict,
+    index_name: str,
+) -> Path | None:
+    """Extract individual PEP 740 attestation from provenance wrapper.
+
+    The PyPI Integrity API returns a provenance wrapper with
+    attestation_bundles[].attestations[], but the pypi-attestations CLI
+    expects individual Attestation objects as .publish.attestation files.
+    """
+    bundles = provenance.get("attestation_bundles", [])
+    if not bundles:
+        return None
+    attestations = bundles[0].get("attestations", [])
+    if not attestations:
+        return None
+
+    # Save next to the artifact for CLI consumption
+    att_file = path.parent / f"{path.name}.publish.attestation"
+    att_file.write_text(json.dumps(attestations[0]))
+
+    # Also save to proofs/pypi/ for archival
+    pypi_proofs = _ensure_proofs_dir() / "pypi"
+    pypi_proofs.mkdir(exist_ok=True)
+    suffix = "testpypi" if index_name == "TestPyPI" else "pypi"
+    proof_att = pypi_proofs / f"{path.name}.{suffix}-attestation.json"
+    proof_att.write_text(json.dumps(attestations[0]))
+
+    return att_file
+
+
+def inspect_attestation(att_file: Path) -> None:
+    """Run pypi-attestations inspect to display attestation details."""
+    result = run(["uv", "run", "pypi-attestations", "inspect", str(att_file)])
+    # inspect writes to stderr (uses rich console internally)
+    output = result.stderr or result.stdout
+    if result.returncode == 0 and output:
+        for line in output.strip().splitlines():
+            info(line)
+
+
 def verify_pypi_attestation(
     path: Path,
     provenance: dict,
     index_name: str,
+    version: str,
 ) -> bool:
-    """Verify PyPI PEP 740 attestation cryptographically."""
-    from pypi_attestations import Attestation, AttestationError, GitHubPublisher
-    from pypi_attestations import Distribution as AttestDist
+    """Verify PyPI PEP 740 attestation using pypi-attestations CLI.
 
+    Uses 'pypi-attestations inspect' for details and
+    'pypi-attestations verify attestation' for cryptographic verification.
+    """
     bundles = provenance.get("attestation_bundles", [])
     if not bundles:
         fail(f"No attestation bundles in {index_name} provenance")
         return False
 
-    all_ok = True
-    dist = AttestDist.from_file(path)
+    # Extract individual attestation file for CLI
+    att_file = extract_attestation_file(path, provenance, index_name)
+    if not att_file:
+        fail(f"Could not extract attestation from {index_name} provenance")
+        return False
+    info(f"Extracted attestation to {att_file.name}")
 
-    for bundle in bundles:
-        publisher_data = bundle.get("publisher", {})
-        attestations = bundle.get("attestations", [])
+    # Inspect attestation details (unverified display)
+    inspect_attestation(att_file)
 
-        publisher = GitHubPublisher(
-            repository=publisher_data.get("repository", ""),
-            workflow=publisher_data.get("workflow", ""),
-            environment=publisher_data.get("environment"),
-        )
+    # Build identity from publisher data
+    publisher_data = bundles[0].get("publisher", {})
+    repo = publisher_data.get("repository", REPO_SLUG)
+    workflow = publisher_data.get("workflow", RELEASE_WORKFLOW)
+    identity = (
+        f"https://github.com/{repo}/.github/workflows/{workflow}@refs/tags/{TAG_PREFIX}{version}"
+    )
 
-        for att_data in attestations:
-            att = Attestation.model_validate(att_data)
-            artifact_hash = sha256(path)
-            try:
-                predicate_type, predicate = att.verify(publisher, dist)
-                repo = publisher_data.get("repository", "?")
-                wf = publisher_data.get("workflow", "?")
-                ok(f"{index_name}: {path.name} ({artifact_hash})")
-                info(f"  signed by: {repo}/{wf}")
-                info(f"  environment: {publisher_data.get('environment', '?')}")
-                info("  trust root: https://token.actions.githubusercontent.com")
-            except (AttestationError, ValueError) as exc:
-                fail(f"{index_name}: {path.name}")
-                fail(f"  artifact: {artifact_hash}")
-                fail(f"  error: {exc}")
-                all_ok = False
-                predicate_type = "?"
-                continue
+    # Verify with pypi-attestations CLI
+    result = run(
+        [
+            "uv",
+            "run",
+            "pypi-attestations",
+            "verify",
+            "attestation",
+            "--identity",
+            identity,
+            str(path),
+        ]
+    )
 
-            # Display verified publisher and attestation details
-            table = Table(
-                title=f"{index_name} PEP 740 Attestation (verified)",
-                show_header=False,
-                padding=(0, 2),
-                expand=True,
-            )
-            table.add_column("Field", style="bold cyan", min_width=24, max_width=30)
-            table.add_column("Value", overflow="fold")
+    artifact_hash = sha256(path)
+    if result.returncode != 0:
+        fail(f"{index_name}: {path.name}")
+        fail(f"  artifact: {artifact_hash}")
+        if result.stderr:
+            fail(f"  error: {result.stderr.strip()}")
+        return False
 
-            table.add_row("Publisher kind", publisher_data.get("kind", "?"))
-            table.add_row("Repository", publisher_data.get("repository", "?"))
-            table.add_row("Workflow", publisher_data.get("workflow", "?"))
-            table.add_row("Environment", publisher_data.get("environment", "?"))
-            table.add_row("Predicate type", predicate_type)
-            table.add_row("Artifact", path.name)
-            table.add_row("SHA256", sha256(path))
+    ok(f"{index_name}: {path.name} ({artifact_hash})")
+    info("  verified by: pypi-attestations verify attestation")
+    info(f"  signed by: {repo}/{workflow}")
+    info(f"  environment: {publisher_data.get('environment', '?')}")
+    info(f"  trust root: {OIDC_ISSUER}")
 
-            console.print()
-            console.print(table)
+    # Display publisher details table
+    table = Table(
+        title=f"{index_name} PEP 740 Attestation (verified)",
+        show_header=False,
+        padding=(0, 2),
+        expand=True,
+    )
+    table.add_column("Field", style="bold cyan", min_width=24, max_width=30)
+    table.add_column("Value", overflow="fold")
+    table.add_row("Publisher kind", publisher_data.get("kind", "?"))
+    table.add_row("Repository", publisher_data.get("repository", "?"))
+    table.add_row("Workflow", publisher_data.get("workflow", "?"))
+    table.add_row("Environment", publisher_data.get("environment", "?"))
+    table.add_row("Predicate type", "https://docs.pypi.org/attestations/publish/v1")
+    table.add_row("Artifact", path.name)
+    table.add_row("SHA256", artifact_hash)
+    console.print()
+    console.print(table)
 
-    return all_ok
+    return True
 
 
 def save_provenance_to_proofs(
@@ -660,7 +737,7 @@ def main() -> int:
             prov = fetch_pypi_provenance(PACKAGE_NAME, version, name, base_url)
             if prov:
                 save_provenance_to_proofs(prov, name, index_name)
-                if not verify_pypi_attestation(path, prov, index_name):
+                if not verify_pypi_attestation(path, prov, index_name, version):
                     failures += 1
             else:
                 info(f"{index_name}: no attestation for {name}")

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -506,8 +506,6 @@ def main() -> int:
 
     # -- 5. PyPI / TestPyPI attestations (PEP 740) ---------------------
     header("5. PyPI / TestPyPI attestations (pypi-attestations library)")
-    pypi_proofs = _ensure_proofs_dir() / "pypi"
-    pypi_proofs.mkdir(exist_ok=True)
     for index_name, base_url in PYPI_INDEXES:
         if index_name == "TestPyPI":
             console.print(
@@ -516,10 +514,13 @@ def main() -> int:
                     border_style="yellow",
                 )
             )
+        index_dir = "testpypi" if index_name == "TestPyPI" else "pypi"
+        proofs_dir = _ensure_proofs_dir() / index_dir
+        proofs_dir.mkdir(exist_ok=True)
         for name, path in artifacts.items():
             prov = fetch_pypi_provenance(PACKAGE_NAME, version, name, base_url)
             if prov:
-                out = pypi_proofs / f"{name}.{index_name.lower()}-provenance.json"
+                out = proofs_dir / f"{name}.provenance.json"
                 out.write_text(json.dumps(prov, indent=2))
                 if not verify_pypi_attestation(path, prov, index_name):
                     failures += 1

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -29,7 +29,9 @@ import json
 import shutil
 import subprocess
 import sys
+import tomllib
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -40,12 +42,30 @@ from rich.table import Table
 console = Console()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-REPO_OWNER = "IvanAnishchuk"
-REPO_NAME = "geek42"
-REPO_SLUG = f"{REPO_OWNER}/{REPO_NAME}"
-PACKAGE_NAME = "geek42"
 DIST_EXTENSIONS = (".whl", ".tar.gz")
-OIDC_ISSUER = "https://token.actions.githubusercontent.com"
+
+# Known CI providers and their OIDC issuers
+KNOWN_HOSTS = {
+    "github.com": "https://token.actions.githubusercontent.com",
+}
+
+# -- Trust anchors (derived from pyproject.toml) ---------------------------
+
+_pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+PACKAGE_NAME = _pyproject["project"]["name"]
+_repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
+_repo_host = _repo_url.hostname
+if _repo_host not in KNOWN_HOSTS:
+    console.print(f"[bold red]Unknown repository host: {_repo_host}[/]")
+    console.print(f"[dim]Known hosts: {', '.join(KNOWN_HOSTS)}[/]")
+    sys.exit(1)
+REPO_SLUG = _repo_url.path.strip("/")
+OIDC_ISSUER = KNOWN_HOSTS[_repo_host]
+
+# Release conventions — update these if your project uses different values
+RELEASE_WORKFLOW = "release.yml"
+TAG_PREFIX = "v"  # tags are formatted as v{version}, e.g. v0.4.2a7
+
 PYPI_INDEXES = [
     ("PyPI", "https://pypi.org"),
     ("TestPyPI", "https://test.pypi.org"),
@@ -147,9 +167,7 @@ def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
     from sigstore.models import Bundle
     from sigstore.verify import Verifier, policy
 
-    identity_str = (
-        f"https://github.com/{REPO_SLUG}/.github/workflows/release.yml@refs/tags/v{version}"
-    )
+    identity_str = f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
 
     try:
         bundle = Bundle.from_json(bundle_path.read_bytes())
@@ -455,7 +473,7 @@ def main() -> int:
             identity = policy.Identity(
                 identity=(
                     f"https://github.com/{REPO_SLUG}"
-                    f"/.github/workflows/release.yml@refs/tags/v{version}"
+                    f"/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
                 ),
                 issuer=OIDC_ISSUER,
             )
@@ -475,7 +493,7 @@ def main() -> int:
                 continue
 
             ok(f"GH attestation verified: {name} ({artifact_hash})")
-            info(f"  signed by: release.yml@refs/tags/v{version}")
+            info(f"  signed by: {RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}")
             info(f"  trust root: {OIDC_ISSUER}")
         except (
             sigstore.errors.VerificationError,


### PR DESCRIPTION
## Summary

Addresses #35, #36, #37:

- **#36**: `verify_provenance.py` now uses `pypi-attestations` CLI (`verify attestation` + `inspect`) instead of importing the Python library. `verify_cosign.py` adds `inspect` output after cosign PEP 740 verification. `verify_pure.py` keeps the Python library approach (no changes to verification logic).
- **#35**: `download_release.py` now fetches from all three sources (GitHub Release, GitHub Attestation API, PyPI/TestPyPI Integrity API) and extracts all proof formats (`.publish.attestation`, cosign-compatible bundles, GH attestation bundles). Verify scripts use pre-extracted files when available, with inline extraction as fallback.
- **#37**: Trust anchors (repo slug, package name, OIDC issuer) derived from `pyproject.toml` instead of hardcoded. Repository host validated against `KNOWN_HOSTS`. `RELEASE_WORKFLOW` and `TAG_PREFIX` constants added for configurability.

Also adds `docs/pypi-attestations-cli-research.md` documenting CLI findings.

## Test plan

- [x] All 158 pytest tests pass
- [x] `ruff check`, `ruff format`, `ty check` pass
- [x] Pre-commit hooks pass (including conventional commit)
- [x] `verify_provenance.py 0.4.2a7` — all OK with good files, all FAIL on tampered whl
- [x] `verify_cosign.py 0.4.2a7` — all OK with good files, all FAIL on tampered whl
- [x] `verify_pure.py 0.4.2a7` — all OK with good files, all FAIL on tampered whl

Closes #35, closes #36, closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)