### PR TITLE
fix: pin slsa-github-generator to commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
       contents: write    # upload-assets job inside reusable workflow requires write
       id-token: write
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: ${{ needs.build.outputs.hashes }}
       upload-assets: false


### PR DESCRIPTION
## Summary

- Pin `slsa-framework/slsa-github-generator` to commit SHA `f7dd8c54` (v2.1.0) in `release.yml`
- All other actions were already pinned by SHA — this was the only one using a tag reference

Closes #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)