### PR TITLE
feat: add Gemini Code Assist and CodeRabbit as PR reviewers

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,7 +7,8 @@ reviews:
   instructions: |
     This is a Python 3.13+ CLI tool using uv, hatchling, typer, rich, pydantic.
     Ruff for linting (line-length 100), ty for type checking, pytest with 75%
-    coverage floor. Conventional Commits required. No shell scripts or Makefiles.
+    coverage floor. Conventional Commits required. Prefer Python scripts over
+    shell scripts or Makefiles for tooling.
     All subprocess calls must use list args (no shell=True). Every noqa must
     document why. Every PR must update CHANGELOG.md under [Unreleased]. Versions
     follow PEP 440 (not SemVer). Supply-chain security: SLSA L3, sigstore,

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@ language: en-US
 reviews:
   profile: assertive
 
-  instructions: |
+  high_level_summary_instructions: |
     This is a Python 3.13+ CLI tool using uv, hatchling, typer, rich, pydantic.
     Ruff for linting (line-length 100), ty for type checking, pytest with 75%
     coverage floor. Conventional Commits required. Prefer Python scripts over
@@ -17,7 +17,7 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    incremental_reviews: true
+    auto_incremental_review: true
 
   request_changes_workflow: false
   high_level_summary: true
@@ -47,7 +47,6 @@ reviews:
       instructions: "All actions must be pinned by SHA with a version comment."
 
   tools:
-    enabled: true
     ruff:
       enabled: true
     shellcheck:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+
+reviews:
+  profile: assertive
+
+  instructions: |
+    This is a Python 3.13+ CLI tool using uv, hatchling, typer, rich, pydantic.
+    Ruff for linting (line-length 100), ty for type checking, pytest with 75%
+    coverage floor. Conventional Commits required. No shell scripts or Makefiles.
+    All subprocess calls must use list args (no shell=True). Every noqa must
+    document why. Every PR must update CHANGELOG.md under [Unreleased]. Versions
+    follow PEP 440 (not SemVer). Supply-chain security: SLSA L3, sigstore,
+    PEP 740 attestations. All workflow actions pinned by SHA.
+
+  auto_review:
+    enabled: true
+    drafts: false
+    incremental_reviews: true
+
+  request_changes_workflow: false
+  high_level_summary: true
+  collapse_walkthrough: false
+  changed_files_summary: true
+  sequence_diagrams: false
+  poem: false
+  review_status: true
+  commit_status: true
+  fail_commit_status: false
+  abort_on_close: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: false
+  auto_assign_reviewers: false
+
+  path_filters:
+    - "!**/*.lock"
+    - "!requirements*.txt"
+
+  path_instructions:
+    - path: "src/**"
+      instructions: "Check for narrow exception types, no bare Exception catches, validated URLs, documented noqa."
+    - path: "scripts/**"
+      instructions: "Verify subprocess calls use list args. Check trust anchors are derived from pyproject.toml."
+    - path: ".github/workflows/**"
+      instructions: "All actions must be pinned by SHA with a version comment."
+
+  tools:
+    enabled: true
+    ruff:
+      enabled: true
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    yamllint:
+      enabled: true
+
+chat:
+  auto_reply: true

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,7 @@
+code_review:
+  comment_severity_threshold: MEDIUM
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: false

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,30 @@
+# geek42 Style Guide for Gemini Code Assist
+
+## Language and tooling
+
+- Python 3.13+, src layout, hatchling build backend
+- ruff for linting (line-length 100) and formatting
+- ty for type checking
+- pytest with 75% coverage floor
+- uv as package manager (never raw pip)
+- No shell scripts or Makefiles — Python scripts only
+
+## Code conventions
+
+- Conventional Commits required for all commit messages
+- Narrow exception types — no bare `except Exception`
+- All `# noqa` comments must document why
+- subprocess calls must use list args, never `shell=True`
+- URLs must be validated before fetching
+- Prefer editing existing files over creating new ones
+
+## Security
+
+- Supply-chain: SLSA L3, sigstore, PEP 740 attestations on every release
+- All actions in workflows pinned by SHA with version comment
+- Trust anchors derived from pyproject.toml, not hardcoded
+
+## Changelog
+
+- Every PR must update CHANGELOG.md under [Unreleased]
+- Versions follow PEP 440 (not SemVer)

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -7,7 +7,7 @@
 - ty for type checking
 - pytest with 75% coverage floor
 - uv as package manager (never raw pip)
-- No shell scripts or Makefiles — Python scripts only
+- No checked-in shell scripts or Makefiles — prefer Python scripts for tooling
 
 ## Code conventions
 

--- a/.github/codex-instructions.md
+++ b/.github/codex-instructions.md
@@ -1,0 +1,42 @@
+# Codex instructions for geek42
+
+## Project
+
+Pure Python CLI tool (Python 3.13+) using uv, hatchling, typer, rich,
+pydantic. Converts GLEP 42 Gentoo news repos into static blogs.
+
+## Conventions
+
+- **Commits:** Conventional Commits format required (`feat:`, `fix:`, etc.)
+- **Formatting:** ruff (line length 100, target py313)
+- **Type checking:** ty
+- **Testing:** pytest with 75% coverage floor
+- **Package manager:** uv (never raw pip)
+- Prefer Python scripts over shell scripts or Makefiles for tooling
+
+## Security
+
+- All subprocess calls use list args (no shell=True)
+- Exception catches should be as narrow as possible
+- URLs must be validated before fetching
+- Every noqa comment must document why it's necessary
+- Supply-chain: SLSA L3, sigstore, PEP 740 attestations on every release
+- All actions in workflows pinned by SHA with version comment
+
+## Changelog
+
+- Every PR must have a corresponding `CHANGELOG.md` entry under `[Unreleased]`
+- When reviewing, check that user-visible changes have changelog entries
+- Changelog uses PEP 440 versions, not SemVer
+
+## Review process
+
+When reviewing PRs:
+- Triage every comment, including low-confidence hidden ones
+- For actionable findings: fix in the PR or create a GitHub issue and link it
+- Never dismiss comments without explicit owner confirmation
+- Reply with linked issue number or reason before resolving conversations
+- After changes are made, re-review before approving
+- Verify that CHANGELOG.md is updated for user-visible changes
+
+This applies to all reviewers: Copilot, Gemini Code Assist, CodeRabbit, Codex, and humans.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,3 +56,5 @@ When reviewing PRs:
 - Reply with linked issue number or reason before resolving conversations
 - After changes are made, re-review before approving
 - Verify that CHANGELOG.md is updated for user-visible changes
+
+This applies to all reviewers: Copilot, Gemini Code Assist, CodeRabbit, and humans.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ## [Unreleased]
 
+### Added
+
+- Gemini Code Assist and CodeRabbit as PR reviewers with
+  repo-level configuration (#46).
+
 ### Changed
 
 - Derive trust anchors (repo slug, package name, OIDC issuer) from
@@ -17,8 +22,6 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 - Replace versioned ebuilds with single `-9999` live ebuild that
   supports both git and PyPI via PV conditional. Add `gen_ebuild.py`
   script to generate versioned copies at release time (#55).
-- Add Gemini Code Assist and CodeRabbit as PR reviewers with
-  repo-level configuration (#46).
 
 ## [0.4.2a7] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 - Replace versioned ebuilds with single `-9999` live ebuild that
   supports both git and PyPI via PV conditional. Add `gen_ebuild.py`
   script to generate versioned copies at release time (#55).
+- Add Gemini Code Assist and CodeRabbit as PR reviewers with
+  repo-level configuration (#46).
 
 ## [0.4.2a7] - 2026-04-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Proof files: `proofs/{github,pypi}/`. Distribution files: `dist/`.
 
 After creating a PR:
 
-1. **Request AI reviews** on every PR (Copilot, Gemini Code Assist, etc.).
+1. **Request AI reviews** on every PR (Copilot, Gemini Code Assist, CodeRabbit).
 2. **Triage every review comment**, including low-confidence hidden ones.
    Expand "Show hidden" to see all comments — don't skip them.
 3. **For each actionable comment:**
@@ -152,7 +152,7 @@ After creating a PR:
 6. **After addressing comments**, request a new review and wait for it
    to complete before merging. Repeat until all comments are resolved.
 
-This applies to all reviewers: Copilot, Gemini Code Assist, Codex, and humans.
+This applies to all reviewers: Copilot, Gemini Code Assist, CodeRabbit, and humans.
 
 ## Code quality
 


### PR DESCRIPTION
## Summary

- Add `.gemini/config.yaml` and `.gemini/styleguide.md` for Gemini Code Assist auto-review
- Add `.coderabbit.yaml` with assertive review profile, path-specific instructions, and linter integration (ruff, shellcheck, markdownlint, yamllint)
- Update CLAUDE.md to reference all three AI reviewers (Copilot, Gemini, CodeRabbit)
- Both apps must be installed on the repo via GitHub UI (separate step)

Closes #46.

## Test plan

- [x] Pre-commit passes
- [x] YAML configs are valid
- [ ] Verify Gemini Code Assist reviews this PR (if app is installed)
- [ ] Verify CodeRabbit reviews this PR (if app is installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository-level configuration to enable automated AI-assisted code reviews with defined review profiles, tooling checks, and PR reporting options.
* **Documentation**
  * Added and updated project guidance covering coding standards, testing/coverage expectations, commit/changelog/versioning rules, and supply-chain security/release requirements.
* **Changelog**
  * Documented the new AI reviewer configuration under Unreleased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->