### PR TITLE
fix: dependency-review deprecation and snapshot warnings

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,7 +29,30 @@ jobs:
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: always
-          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, CC0-1.0, Unlicense, PSF-2.0, 0BSD, CC-BY-4.0
+          allow-licenses: >-
+            WTFPL,
+            0BSD,
+            CC0-1.0,
+            Unlicense,
+            MIT,
+            ISC,
+            Apache-2.0,
+            BSD-2-Clause,
+            BSD-3-Clause,
+            PSF-2.0,
+            Artistic-2.0,
+            Zlib,
+            MPL-2.0,
+            CC-BY-4.0,
+            CC-BY-SA-4.0,
+            LGPL-2.1-only,
+            LGPL-2.1-or-later,
+            LGPL-3.0-only,
+            LGPL-3.0-or-later,
+            GPL-2.0-only,
+            GPL-2.0-or-later,
+            GPL-3.0-only,
+            GPL-3.0-or-later
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 120
           show-openssf-scorecard: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,4 +29,7 @@ jobs:
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: always
-          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
+          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, CC0-1.0, Unlicense, PSF-2.0, 0BSD, CC-BY-4.0
+          retry-on-snapshot-warnings: true
+          retry-on-snapshot-warnings-timeout: 120
+          show-openssf-scorecard: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,7 +29,22 @@ jobs:
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: always
-          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, CC0-1.0, Unlicense, PSF-2.0, 0BSD, CC-BY-4.0
+          allow-licenses: >-
+            MIT,
+            Apache-2.0,
+            BSD-2-Clause,
+            BSD-3-Clause,
+            ISC,
+            CC0-1.0,
+            Unlicense,
+            PSF-2.0,
+            0BSD,
+            CC-BY-4.0,
+            GPL-2.0-only,
+            GPL-2.0-or-later,
+            GPL-3.0-only,
+            GPL-3.0-or-later,
+            WTFPL-2.0
           retry-on-snapshot-warnings: true
           retry-on-snapshot-warnings-timeout: 120
           show-openssf-scorecard: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -33,7 +33,7 @@ jobs:
             0BSD,
             CC0-1.0,
             Unlicense,
-            WTFPL-2.0,
+            WTFPL,
             MIT,
             ISC,
             Apache-2.0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
   `pyproject.toml` instead of hardcoding in verify scripts (#37).
 - Add `RELEASE_WORKFLOW` and `TAG_PREFIX` constants for configurability.
 - Pin `slsa-github-generator` to commit SHA (#49).
+
+### Fixed
+
+- Replace deprecated `deny-licenses` with `allow-licenses` in
+  dependency-review workflow. Enable `retry-on-snapshot-warnings`
+  to fix empty scan results (#76).
 - Replace versioned ebuilds with single `-9999` live ebuild that
   supports both git and PyPI via PV conditional. Add `gen_ebuild.py`
   script to generate versioned copies at release time (#55).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ### Fixed
 
-- Replace deprecated `deny-licenses` with `allow-licenses` in
-  dependency-review workflow. Enable `retry-on-snapshot-warnings`
-  and `show-openssf-scorecard` to fix empty scan results (#76).
+- Replace deprecated `deny-licenses` with `allow-licenses` allowlist
+  in dependency-review workflow. Expand license policy to include
+  copyleft (GPL, LGPL, MPL, WTFPL) alongside permissive licenses.
+  Enable `retry-on-snapshot-warnings` and `show-openssf-scorecard`
+  to fix empty scan results (#76).
 
 ## [0.4.2a7] - 2026-04-12
 
@@ -385,7 +387,7 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 - `.github/workflows/gitleaks.yml` — secret scanning on push, PR, and
   schedule
 - `.github/workflows/dependency-review.yml` — PR-time dependency diff
-  with moderate-severity gate and GPL license denylist
+  with moderate-severity gate and license allowlist
 
 #### Release pipeline
 - `.github/workflows/release.yml` — full release pipeline triggered on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,15 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
   `pyproject.toml` instead of hardcoding in verify scripts (#37).
 - Add `RELEASE_WORKFLOW` and `TAG_PREFIX` constants for configurability.
 - Pin `slsa-github-generator` to commit SHA (#49).
+- Replace versioned ebuilds with single `-9999` live ebuild that
+  supports both git and PyPI via PV conditional. Add `gen_ebuild.py`
+  script to generate versioned copies at release time (#55).
 
 ### Fixed
 
 - Replace deprecated `deny-licenses` with `allow-licenses` in
   dependency-review workflow. Enable `retry-on-snapshot-warnings`
-  to fix empty scan results (#76).
-- Replace versioned ebuilds with single `-9999` live ebuild that
-  supports both git and PyPI via PV conditional. Add `gen_ebuild.py`
-  script to generate versioned copies at release time (#55).
+  and `show-openssf-scorecard` to fix empty scan results (#76).
 
 ## [0.4.2a7] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 - Replace deprecated `deny-licenses` with `allow-licenses` allowlist
   in dependency-review workflow. Expand license policy to include
-  copyleft (GPL, LGPL, MPL, WTFPL) alongside permissive licenses.
+  copyleft (GPL, LGPL, MPL) and public domain (WTFPL) alongside
+  permissive licenses.
   Enable `retry-on-snapshot-warnings` and `show-openssf-scorecard`
   to fix empty scan results (#76).
 
@@ -387,7 +388,7 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 - `.github/workflows/gitleaks.yml` — secret scanning on push, PR, and
   schedule
 - `.github/workflows/dependency-review.yml` — PR-time dependency diff
-  with moderate-severity gate and license allowlist
+  with moderate-severity gate and GPL license denylist
 
 #### Release pipeline
 - `.github/workflows/release.yml` — full release pipeline triggered on

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -382,7 +382,8 @@ Scans the full git history on every push and PR using
 
 Runs on PRs only. Fails on any dependency introduction with
 moderate+ vulnerabilities or licenses not on the allowlist.
-Posts a summary comment on the PR. Allowed licenses include
+Posts a summary comment on the PR with OpenSSF Scorecard context.
+Allowed licenses include
 permissive (MIT, Apache-2.0, BSD, ISC, etc.), copyleft (GPL, LGPL,
 MPL), and public domain dedications (CC0, 0BSD, Unlicense, WTFPL).
 See `.github/workflows/dependency-review.yml` for the full list.

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -381,8 +381,11 @@ Scans the full git history on every push and PR using
 ### `dependency-review.yml` — dependency diff
 
 Runs on PRs only. Fails on any dependency introduction with
-moderate+ vulnerabilities or forbidden licenses (GPL-2/3, AGPL).
-Posts a summary comment on the PR.
+moderate+ vulnerabilities or licenses not on the allowlist.
+Posts a summary comment on the PR. Allowed licenses include
+permissive (MIT, Apache-2.0, BSD, ISC, etc.), copyleft (GPL, LGPL,
+MPL), and public domain dedications (CC0, 0BSD, Unlicense, WTFPL).
+See `.github/workflows/dependency-review.yml` for the full list.
 
 ### Required status checks
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -88,7 +88,7 @@ for the repo-owner configuration checklist see
   sync with `pyproject.toml` or hashes don't match
 - **Dependabot** — weekly grouped PRs for minor/patch updates
 - **Dependency review** (PR-time) — blocks introductions of
-  moderate-severity vulns and forbidden licenses (GPL-2/3, AGPL)
+  moderate-severity vulns and unlisted licenses (allowlist-based)
 - **pip-audit** — runs on every CI build against the exported
   requirements, fails on any known vuln
 - **CycloneDX SBOM** — generated and attested with every release


### PR DESCRIPTION
## Summary

- Replace deprecated `deny-licenses` with `allow-licenses` allowlist
  (23 licenses: 0BSD, CC0-1.0, Unlicense, WTFPL, MIT, ISC, Apache-2.0,
  BSD-2/3-Clause, PSF-2.0, Artistic-2.0, Zlib, MPL-2.0, CC-BY-4.0,
  CC-BY-SA-4.0, LGPL-2.1/3.0, GPL-2.0/3.0)
- Enable `retry-on-snapshot-warnings` with 120s timeout so dependency
  diffs are actually scanned
- Enable `show-openssf-scorecard` for additional dependency context
- Multi-line YAML format for readability

Closes #76.

## Test plan

- [x] Pre-commit passes
- [x] Dependency review check passes with no deprecation warning
- [ ] Scanned files shown instead of "None"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Resolves deprecation and snapshot warnings in the GitHub Actions dependency review workflow. Replaces the deprecated `deny-licenses` configuration with an explicit `allow-licenses` allowlist, expands the license policy to include copyleft licenses (GPL, LGPL, MPL variants with `-only` and `-or-later` suffixes) and public domain designations (WTFPL, CC0-1.0, 0BSD, Unlicense) alongside permissive licenses (MIT, Apache-2.0, BSD, ISC, etc.), and enables snapshot warning retry behavior with a 120-second timeout and OpenSSF Scorecard integration to ensure dependency diffs are properly scanned. Closes #76.

## Changes

**Workflow configuration** (`.github/workflows/dependency-review.yml`):
- Migrated from `deny-licenses` (deprecated) to `allow-licenses` with 23 explicitly allowed licenses
- Enabled `retry-on-snapshot-warnings: true` with `retry-on-snapshot-warnings-timeout: 120` to ensure dependency submissions on PR branches are found
- Enabled `show-openssf-scorecard: true` for additional dependency context in PR comments
- Reformatted as multi-line YAML for improved readability

**Documentation**:
- Updated `CHANGELOG.md` with Fixed section documenting the deprecation replacement and license policy expansion
- Updated `docs/devops.md` to replace specific forbidden license naming with "licenses not on the allowlist" and clarify that PR comments now include OpenSSF Scorecard context
- Updated `docs/security.md` to reflect allowlist-based dependency review (rather than denylist)

## Alignment

- Addresses all requirements from issue #76: deprecated option removal, snapshot warning resolution, and expanded license scope
- Follows project conventions: CHANGELOG.md updated in [Unreleased] section, documentation synchronized, all workflow actions pinned by SHA
- Conventional Commits compliant (fix: prefix)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->