### PR TITLE
chore(release): v0.4.2a8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ## [Unreleased]
 
+## [0.4.2a8] - 2026-04-12
+
 ### Added
 
 - Gemini Code Assist and CodeRabbit as PR reviewers with

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN uv sync --frozen --no-dev
 FROM python:${PYTHON_VERSION}-${DEBIAN_SUITE} AS runtime
 
 # OCI image labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
-ARG VERSION=0.4.2a7
+ARG VERSION=0.4.2a8
 ARG REVISION=unknown
 ARG BUILD_DATE=unknown
 LABEL org.opencontainers.image.title="geek42" \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,14 @@
+geek42 (0.4.2~a8-1) unstable; urgency=medium
+
+  * New upstream pre-release.
+  * pypi-attestations CLI integration.
+  * Trust anchors derived from pyproject.toml.
+  * Gemini Code Assist and CodeRabbit PR reviewers.
+  * Dependency-review allowlist policy.
+  * See CHANGELOG.md for details.
+
+ -- Ivan Anishchuk <ivan@agorism.org>  Sat, 12 Apr 2026 00:00:00 +0000
+
 geek42 (0.4.2~a7-1) unstable; urgency=medium
 
   * New upstream pre-release.

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -7,7 +7,7 @@ geek42 (0.4.2~a8-1) unstable; urgency=medium
   * Dependency-review allowlist policy.
   * See CHANGELOG.md for details.
 
- -- Ivan Anishchuk <ivan@agorism.org>  Sat, 12 Apr 2026 00:00:00 +0000
+ -- Ivan Anishchuk <ivan@agorism.org>  Sun, 12 Apr 2026 00:00:00 +0000
 
 geek42 (0.4.2~a7-1) unstable; urgency=medium
 

--- a/packaging/rpm/geek42.spec
+++ b/packaging/rpm/geek42.spec
@@ -7,7 +7,7 @@ read/unread tracking, compose and revise workflows, and a built-in
 news file linter with 15 diagnostic rules.}
 
 Name:           %{pypi_name}
-Version:        0.4.2~a7
+Version:        0.4.2~a8
 Release:        1%{?dist}
 Summary:        GLEP 42 Gentoo news to static blog converter
 
@@ -53,6 +53,10 @@ Summary:        %{summary}
 %{_bindir}/geek42
 
 %changelog
+* Sat Apr 12 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.2~a8-1
+- Pre-release: pypi-attestations CLI, trust anchors, AI reviewers,
+  dependency-review allowlist.
+
 * Sat Apr 11 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.2~a7-1
 - Pre-release: SLSA L3 provenance, PEP 740 attestations, versioned proofs.
 

--- a/packaging/rpm/geek42.spec
+++ b/packaging/rpm/geek42.spec
@@ -53,7 +53,7 @@ Summary:        %{summary}
 %{_bindir}/geek42
 
 %changelog
-* Sat Apr 12 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.2~a8-1
+* Sun Apr 12 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.2~a8-1
 - Pre-release: pypi-attestations CLI, trust anchors, AI reviewers,
   dependency-review allowlist.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geek42"
-version = "0.4.2a7"
+version = "0.4.2a8"
 description = "Convert GLEP 42 Gentoo news repositories into static blogs"
 readme = "README.md"
 license = "CC0-1.0"

--- a/src/geek42/__init__.py
+++ b/src/geek42/__init__.py
@@ -42,7 +42,7 @@ from .renderer import body_to_html, news_to_markdown, write_markdown
 from .scaffold import scaffold
 from .tracker import ReadTracker
 
-__version__ = "0.4.2a7"
+__version__ = "0.4.2a8"
 
 __all__ = [
     "ComposeError",

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "geek42"
-version = "0.4.2a7"
+version = "0.4.2a8"
 source = { editable = "." }
 dependencies = [
     { name = "gemato" },


### PR DESCRIPTION
## Release v0.4.2a8

### Highlights

- **pypi-attestations CLI** for PEP 740 verification in verify_provenance.py (#36)
- **Trust anchors** derived from pyproject.toml instead of hardcoded (#37)
- **Format conversions** moved to download_release.py (#35)
- **SLSA generator** pinned to commit SHA (#49)
- **-9999 ebuild** replaces versioned ebuilds (#55)
- **Gemini Code Assist + CodeRabbit** as PR reviewers (#46)
- **Dependency-review** allowlist replaces deprecated denylist (#76)
- **CHANGELOG** backfilled for a2-a7, PEP 440 versioning (#59, #62)

### Version bumped in

- [x] pyproject.toml
- [x] src/geek42/__init__.py
- [x] Dockerfile
- [x] packaging/debian/changelog
- [x] packaging/rpm/geek42.spec
- [x] uv.lock + requirements*.txt regenerated
- [x] gen_ebuild.py run

🤖 Generated with [Claude Code](https://claude.com/claude-code)