### PR TITLE
fix: enable SLSA upload-assets and private-repository flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,8 @@ jobs:
 
   # -------------------------------------------------------------------
   # SLSA Level 3 provenance generator (reusable workflow).
-  # Requires contents: write even with upload-assets: false due to
-  # static permission validation (slsa-github-generator#2044).
+  # upload-assets: true uploads provenance directly to the GitHub Release.
+  # private-repository: true works around false-positive private repo detection.
   # -------------------------------------------------------------------
   provenance:
     name: SLSA L3 provenance
@@ -114,7 +114,8 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: ${{ needs.build.outputs.hashes }}
-      upload-assets: false
+      upload-assets: true
+      private-repository: true
       provenance-name: geek42-${{ github.ref_name }}-provenance.intoto.jsonl
 
   # -------------------------------------------------------------------
@@ -241,12 +242,6 @@ jobs:
           name: release-dist
           path: release-dist/
 
-      - name: Download SLSA provenance
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: geek42-${{ github.ref_name }}-provenance.intoto.jsonl
-          path: release-dist/
-
       - name: Extract release notes from CHANGELOG
         id: notes
         run: |
@@ -271,7 +266,6 @@ jobs:
             release-dist/dist/geek42-*-sbom.cdx.json
             release-dist/dist/geek42-*-SHA256SUMS.txt
             release-dist/dist/*.sigstore.json
-            release-dist/geek42-*-provenance.intoto.jsonl
 
       - name: Publish release
         run: gh release edit "$GITHUB_REF_NAME" --draft=false


### PR DESCRIPTION
## Summary

- Set `upload-assets: true` so SLSA generator uploads provenance directly to GitHub Release
- Add `private-repository: true` to work around false positive private repo detection (root cause of v0.4.2a8 release failure)
- Remove manual provenance download from `github-release` job (SLSA handles it now)

Will test with a `.post1` tag after merge.

## Test plan

- [ ] Tag `v0.4.2a8.post1` after merge — SLSA provenance should succeed
- [ ] GitHub Release should be created with all artifacts including provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Enable direct SLSA L3 provenance upload in the release workflow and add a workaround for a false-positive private-repository detection that caused the previous release failure. Remove manual provenance artifact handling from the GitHub Release job so SLSA handles provenance upload end-to-end.

## Changes

### `.github/workflows/release.yml`
- Set `upload-assets: true` in the SLSA provenance generator so provenance is uploaded directly to the GitHub Release.
- Added `private-repository: true` to the provenance generator inputs to bypass a false-positive private repo detection that previously blocked the v0.4.2a8 release.
- Removed the manual download step for the `.intoto.jsonl` provenance file from the `github-release` job and removed the provenance file from the `files:` list passed to the GitHub Release action (provenance is now provided by the SLSA workflow).
- Minor clarifying comments added in the provenance job explaining these flags.

Lines changed: +4 / -10.

## Rationale / Notes
- This change consolidates provenance upload into the SLSA reusable workflow, reducing manual artifact choreography and related failure modes.
- Will be validated by tagging `v0.4.2a8.post1` after merge; expected result: SLSA provenance succeeds and the GitHub Release contains all artifacts including provenance.

## Testing
- Post-merge: create tag `v0.4.2a8.post1` and verify SLSA provenance upload and GitHub Release artifact list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->