### PR TITLE
fix: revert SLSA generator to tag ref, document why

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,7 +12,8 @@ reviews:
     All subprocess calls must use list args (no shell=True). Every noqa must
     document why. Every PR must update CHANGELOG.md under [Unreleased]. Versions
     follow PEP 440 (not SemVer). Supply-chain security: SLSA L3, sigstore,
-    PEP 740 attestations. All workflow actions pinned by SHA.
+    PEP 740 attestations. All workflow actions pinned by SHA
+    (exception: slsa-github-generator pinned by tag, see release.yml).
 
   auto_review:
     enabled: true
@@ -44,7 +45,7 @@ reviews:
     - path: "scripts/**"
       instructions: "Verify subprocess calls use list args. Check trust anchors are derived from pyproject.toml."
     - path: ".github/workflows/**"
-      instructions: "All actions must be pinned by SHA with a version comment."
+      instructions: "All actions must be pinned by SHA with a version comment. Exception: slsa-github-generator is pinned by tag (see release.yml comment)."
 
   tools:
     ruff:

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -22,6 +22,7 @@
 
 - Supply-chain: SLSA L3, sigstore, PEP 740 attestations on every release
 - All actions in workflows pinned by SHA with version comment
+  (exception: slsa-github-generator pinned by tag, see release.yml)
 - Trust anchors derived from pyproject.toml, not hardcoded
 
 ## Changelog

--- a/.github/codex-instructions.md
+++ b/.github/codex-instructions.md
@@ -22,6 +22,7 @@ pydantic. Converts GLEP 42 Gentoo news repos into static blogs.
 - Every noqa comment must document why it's necessary
 - Supply-chain: SLSA L3, sigstore, PEP 740 attestations on every release
 - All actions in workflows pinned by SHA with version comment
+  (exception: slsa-github-generator pinned by tag, see release.yml)
 
 ## Changelog
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,13 @@ jobs:
 
   # -------------------------------------------------------------------
   # SLSA Level 3 provenance generator (reusable workflow).
-  # upload-assets: true uploads provenance directly to the GitHub Release.
-  # private-repository: true works around false-positive private repo detection.
+  # Pinned by tag, NOT SHA. The generator's generate-builder.sh
+  # requires refs/tags/vX.Y.Z to fetch its pre-built binary — commit
+  # SHAs cause "Invalid ref" (exit 2). Tag pinning is acceptable here
+  # because the reusable workflow IS the trust boundary (the caller
+  # cannot tamper with it regardless of the ref format).
+  # Requires contents: write even with upload-assets: false due to
+  # static permission validation (slsa-github-generator#2044).
   # -------------------------------------------------------------------
   provenance:
     name: SLSA L3 provenance
@@ -111,11 +116,10 @@ jobs:
       contents: write    # upload-assets job inside reusable workflow requires write
       id-token: write
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.build.outputs.hashes }}
-      upload-assets: true
-      private-repository: true
+      upload-assets: false
       provenance-name: geek42-${{ github.ref_name }}-provenance.intoto.jsonl
 
   # -------------------------------------------------------------------
@@ -242,6 +246,12 @@ jobs:
           name: release-dist
           path: release-dist/
 
+      - name: Download SLSA provenance
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: geek42-${{ github.ref_name }}-provenance.intoto.jsonl
+          path: release-dist/
+
       - name: Extract release notes from CHANGELOG
         id: notes
         run: |
@@ -266,6 +276,7 @@ jobs:
             release-dist/dist/geek42-*-sbom.cdx.json
             release-dist/dist/geek42-*-SHA256SUMS.txt
             release-dist/dist/*.sigstore.json
+            release-dist/geek42-*-provenance.intoto.jsonl
 
       - name: Publish release
         run: gh release edit "$GITHUB_REF_NAME" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,10 @@ jobs:
   # SLSA Level 3 provenance generator (reusable workflow).
   # Pinned by tag, NOT SHA. The generator's generate-builder.sh
   # requires refs/tags/vX.Y.Z to fetch its pre-built binary — commit
-  # SHAs cause "Invalid ref" (exit 2). Tag pinning is acceptable here
-  # because the reusable workflow IS the trust boundary (the caller
-  # cannot tamper with it regardless of the ref format).
+  # SHAs cause "Invalid ref" (exit 2). This is an accepted exception
+  # to the SHA-pinning policy: tags can be retargeted upstream, but
+  # the reusable workflow runs in an isolated environment the caller
+  # cannot tamper with, and SLSA provenance is independently verifiable.
   # Requires contents: write even with upload-assets: false due to
   # static permission validation (slsa-github-generator#2044).
   # -------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 - Revert SLSA generator to tag ref (`@v2.1.0`) — commit SHA pinning
   breaks `generate-builder.sh` which requires `refs/tags/vX.Y.Z`.
-  Tag pinning is acceptable because the reusable workflow is the
-  trust boundary itself.
+  Accepted exception to SHA-pinning policy: reusable workflow runs
+  in an isolated environment and provenance is independently verifiable.
 
 ## [0.4.2a8] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ## [Unreleased]
 
+### Fixed
+
+- Revert SLSA generator to tag ref (`@v2.1.0`) — commit SHA pinning
+  breaks `generate-builder.sh` which requires `refs/tags/vX.Y.Z`.
+  Tag pinning is acceptable because the reusable workflow is the
+  trust boundary itself.
+
 ## [0.4.2a8] - 2026-04-12
 
 ### Added

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -840,7 +840,12 @@ hashes, and first-class reproducibility features. We standardize on
 
 Tags are mutable on GitHub. A compromised action repository could
 re-point `v4` to a malicious commit and every downstream consumer
-would silently inherit it. SHA pins are immutable.
+would silently inherit it. SHA pins are immutable. Exception:
+`slsa-github-generator` is pinned by tag (`@v2.1.0`) because its
+builder requires `refs/tags/vX.Y.Z` to fetch the pre-built binary.
+This is an accepted risk — the reusable workflow runs in an isolated
+environment the caller cannot tamper with, and the provenance it
+produces is independently verifiable.
 
 **Why both `sigstore` and `SLSA` provenance?**
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -104,7 +104,9 @@ for the repo-owner configuration checklist see
   runner; no persistent state between runs
 - **SHA-pinned actions** — every `uses:` references a specific commit
   SHA, not a tag. Mitigates tag-retargeting attacks on third-party
-  actions.
+  actions. Exception: `slsa-github-generator` reusable workflow is
+  pinned by tag because its `generate-builder.sh` requires
+  `refs/tags/vX.Y.Z` (see `release.yml` comment for rationale).
 - **`step-security/harden-runner`** — first step in every job:
   - Monitors all network egress
   - Audits all process executions


### PR DESCRIPTION
## Summary

Reverts the SLSA generator from commit SHA (`@f7dd8c54`) back to tag
(`@v2.1.0`). The generator's `generate-builder.sh` requires
`refs/tags/vX.Y.Z` to fetch its pre-built binary — commit SHAs cause
`Invalid ref` (exit 2), which was the root cause of the v0.4.2a8
release failure.

Also reverts the experimental `upload-assets: true` and
`private-repository: true` changes from PR #81 — the workflow is
now identical to the last known working version (`b40f37a`) plus an
explanatory comment about why tag pinning is necessary.

Diff against last working version shows only the added comment block.

## Test plan

- [ ] Tag `v0.4.2a8.post2` after merge — full release pipeline should succeed
- [ ] SLSA provenance generated and included in GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes a release pipeline failure by reverting the SLSA L3 provenance generator to tag pinning (@v2.1.0) and restoring the last-known-working workflow behavior, plus cross-project documentation explaining the exception to SHA-only pinning.

## Changes

**.github/workflows/release.yml**
- Reverted reusable SLSA generator `uses:` ref from commit SHA to tag: slsa-framework/slsa-github-generator/...@v2.1.0.
- Set generator input `upload-assets: false` (was true in experimental changes) and removed `private-repository: true`.
- Added a comment block documenting why tag pinning is required: `generate-builder.sh` expects `refs/tags/vX.Y.Z` and commit SHAs produce "Invalid ref" (exit 2); explains accepted exception to SHA-pinning given the isolated reusable workflow and independently verifiable provenance.
- Provenance job now emits provenance artifact name via `provenance-name` and the release job downloads the generated provenance artifact into release-dist/ and includes it in release asset globs.

**CHANGELOG.md**
- Added [Unreleased] → Fixed entry documenting the revert and rationale (tag ref required by generator; accepted exception to SHA-pinning policy).

**Docs & review/config files**
- Added the same exception text across documentation and review config to surface rationale and the risk assessment:
  - .coderabbit.yaml (path-specific instructions)
  - .gemini/styleguide.md
  - .github/codex-instructions.md
  - docs/devops.md
  - docs/security.md

## Rationale

The SLSA generator's internal script requires tag-formatted refs to fetch a pre-built binary; pinning reusable workflow runs by commit SHA caused the generator to fail during the release (Invalid ref). Reverting to a tag ref restores the working release pipeline while maintaining supply-chain assurances because the reusable workflow runs in an isolated environment and the provenance is independently verifiable.

## Test Plan

- After merge, create tag v0.4.2a8.post2 and run the full release pipeline.
- Verify the release completes, SLSA provenance (geek42-<tag>-provenance.intoto.jsonl) is generated, downloaded into release-dist/, and attached to the GitHub Release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->