### PR TITLE
chore(release): v0.4.2a9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ## [Unreleased]
 
+## [0.4.2a9] - 2026-04-12
+
 ### Fixed
 
 - Revert SLSA generator to tag ref (`@v2.1.0`) — commit SHA pinning

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN uv sync --frozen --no-dev
 FROM python:${PYTHON_VERSION}-${DEBIAN_SUITE} AS runtime
 
 # OCI image labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
-ARG VERSION=0.4.2a8
+ARG VERSION=0.4.2a9
 ARG REVISION=unknown
 ARG BUILD_DATE=unknown
 LABEL org.opencontainers.image.title="geek42" \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,11 @@
+geek42 (0.4.2~a9-1) unstable; urgency=medium
+
+  * New upstream pre-release.
+  * Fix SLSA generator tag pinning.
+  * See CHANGELOG.md for details.
+
+ -- Ivan Anishchuk <ivan@agorism.org>  Sun, 12 Apr 2026 00:00:00 +0000
+
 geek42 (0.4.2~a8-1) unstable; urgency=medium
 
   * New upstream pre-release.

--- a/packaging/rpm/geek42.spec
+++ b/packaging/rpm/geek42.spec
@@ -7,7 +7,7 @@ read/unread tracking, compose and revise workflows, and a built-in
 news file linter with 15 diagnostic rules.}
 
 Name:           %{pypi_name}
-Version:        0.4.2~a8
+Version:        0.4.2~a9
 Release:        1%{?dist}
 Summary:        GLEP 42 Gentoo news to static blog converter
 
@@ -53,6 +53,9 @@ Summary:        %{summary}
 %{_bindir}/geek42
 
 %changelog
+* Sun Apr 12 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.2~a9-1
+- Pre-release: fix SLSA generator tag pinning.
+
 * Sun Apr 12 2026 Ivan Anishchuk <ivan@agorism.org> - 0.4.2~a8-1
 - Pre-release: pypi-attestations CLI, trust anchors, AI reviewers,
   dependency-review allowlist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geek42"
-version = "0.4.2a8"
+version = "0.4.2a9"
 description = "Convert GLEP 42 Gentoo news repositories into static blogs"
 readme = "README.md"
 license = "CC0-1.0"

--- a/src/geek42/__init__.py
+++ b/src/geek42/__init__.py
@@ -42,7 +42,7 @@ from .renderer import body_to_html, news_to_markdown, write_markdown
 from .scaffold import scaffold
 from .tracker import ReadTracker
 
-__version__ = "0.4.2a8"
+__version__ = "0.4.2a9"
 
 __all__ = [
     "ComposeError",

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "geek42"
-version = "0.4.2a8"
+version = "0.4.2a9"
 source = { editable = "." }
 dependencies = [
     { name = "gemato" },


### PR DESCRIPTION
## Release v0.4.2a9

### Fix

- Revert SLSA generator to tag ref — commit SHA pinning broke
  `generate-builder.sh`. Documented as accepted exception to
  SHA-pinning policy across all docs.

### Version bumped in

- [x] pyproject.toml, __init__.py, Dockerfile
- [x] packaging/debian/changelog, rpm/geek42.spec
- [x] uv.lock + requirements*.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)