### PR TITLE
refactor: remove inline PyPI fetching from verify scripts (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,17 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
   `chore(deps)(deps):` → `chore(deps):`).
 - Copilot instructions: clarify that "review" means feedback only,
   not committing fixes on behalf of the author.
+- Remove inline PyPI provenance fetching from verify scripts — they
+  now read from `proofs/{pypi,testpypi}/` populated by
+  `download_release.py` (#48).
 
 ### Fixed
 
 - Replace hard-coded tool version badges with dynamic shields.io
   endpoints generated from `uv.lock` (#61).
 - Add uv as dev dependency so its version is tracked in `uv.lock`.
+- Distinguish 404 (no attestation) from network/server errors in
+  `download_release.py`'s `fetch_pypi_provenance` (#48).
 
 ## [0.4.2a9] - 2026-04-12
 

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -274,6 +274,8 @@ def main() -> int:
     fetch_gh_attestations(version)
 
     # 3. PyPI / TestPyPI provenance + extraction
+    # Intentionally let RuntimeError propagate with full traceback —
+    # fetch failures must be visible and loud.
     print("\nFetching PyPI/TestPyPI provenance...")
     extract_pypi_proofs(version)
 

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -182,13 +182,13 @@ def fetch_pypi_provenance(
         if exc.code == 404:
             return None  # no attestation available — expected
         print(f"  Warning: HTTP {exc.code} from {url}")
-        return None
+        raise
     except urllib.error.URLError as exc:
         print(f"  Warning: network error fetching {url}: {exc.reason}")
-        return None
+        raise
     except json.JSONDecodeError:
         print(f"  Warning: invalid JSON from {url}")
-        return None
+        raise
 
 
 def extract_pypi_proofs(version: str) -> None:
@@ -204,7 +204,11 @@ def extract_pypi_proofs(version: str) -> None:
             if not is_dist_file(f.name):
                 continue
 
-            prov = fetch_pypi_provenance(PACKAGE_NAME, version, f.name, base_url)
+            try:
+                prov = fetch_pypi_provenance(PACKAGE_NAME, version, f.name, base_url)
+            except (urllib.error.URLError, json.JSONDecodeError) as exc:
+                print(f"  {index_name}: {f.name} — fetch failed: {exc}")
+                continue
             if not prov:
                 print(f"  {index_name}: {f.name} — no attestation")
                 continue

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -183,8 +183,8 @@ def fetch_pypi_provenance(
             return None  # no attestation available — expected
         print(f"  Warning: HTTP {exc.code} from {url}")
         raise
-    except urllib.error.URLError as exc:
-        print(f"  Warning: network error fetching {url}: {exc.reason}")
+    except OSError as exc:
+        print(f"  Warning: network error fetching {url}: {exc}")
         raise
     except json.JSONDecodeError:
         print(f"  Warning: invalid JSON from {url}")
@@ -206,9 +206,10 @@ def extract_pypi_proofs(version: str) -> None:
 
             try:
                 prov = fetch_pypi_provenance(PACKAGE_NAME, version, f.name, base_url)
-            except (urllib.error.URLError, json.JSONDecodeError) as exc:
+            except (OSError, json.JSONDecodeError) as exc:
                 print(f"  {index_name}: {f.name} — fetch failed: {exc}")
-                continue
+                msg = f"{index_name}: {f.name} — provenance fetch failed"
+                raise RuntimeError(msg) from exc
             if not prov:
                 print(f"  {index_name}: {f.name} — no attestation")
                 continue

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -178,7 +178,16 @@ def fetch_pypi_provenance(
         req = urllib.request.Request(url)  # noqa: S310 — URL validated above
         with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
             return json.loads(resp.read())
-    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError):
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None  # no attestation available — expected
+        print(f"  Warning: HTTP {exc.code} from {url}")
+        return None
+    except urllib.error.URLError as exc:
+        print(f"  Warning: network error fetching {url}: {exc.reason}")
+        return None
+    except json.JSONDecodeError:
+        print(f"  Warning: invalid JSON from {url}")
         return None
 
 

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -539,7 +539,12 @@ def main() -> int:
             if not prov_file.exists():
                 info(f"{index_name}: no attestation for {name}")
                 continue
-            prov = json.loads(prov_file.read_text())
+            try:
+                prov = json.loads(prov_file.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                fail(f"{index_name}: invalid provenance for {name}: {exc}")
+                failures += 1
+                continue
             if not verify_pypi_attestation(path, prov, index_name):
                 failures += 1
 

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -31,9 +31,7 @@ import json
 import subprocess
 import sys
 import tomllib
-import urllib.error
 import urllib.parse
-import urllib.request
 from pathlib import Path
 
 from rich.console import Console
@@ -66,10 +64,7 @@ OIDC_ISSUER = KNOWN_HOSTS[_repo_host]
 RELEASE_WORKFLOW = "release.yml"
 TAG_PREFIX = "v"  # tags are formatted as v{version}, e.g. v0.4.2a7
 
-PYPI_INDEXES = [
-    ("PyPI", "https://pypi.org"),
-    ("TestPyPI", "https://test.pypi.org"),
-]
+PYPI_INDEX_DIRS = ["pypi", "testpypi"]
 
 
 # -- Helpers -----------------------------------------------------------
@@ -265,23 +260,6 @@ def verify_gh_attestation(path: Path, gh_proofs: Path, version: str) -> bool:
     info(f"  signed by: {identity}")
     info(f"  trust root: {OIDC_ISSUER}")
     return True
-
-
-def fetch_pypi_provenance(
-    package: str,
-    version: str,
-    filename: str,
-    base_url: str,
-) -> dict | None:
-    url = f"{base_url}/integrity/{package}/{version}/{filename}/provenance"
-    if not url.startswith(("https://pypi.org/", "https://test.pypi.org/")):
-        return None
-    try:
-        req = urllib.request.Request(url)  # noqa: S310 — URL validated above
-        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
-            return json.loads(resp.read())
-    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError):
-        return None
 
 
 def _restructure_pep740_to_cosign(att: dict) -> dict:
@@ -543,21 +521,27 @@ def main() -> int:
             border_style="dim",
         )
     )
-    for index_name, base_url in PYPI_INDEXES:
-        if index_name == "TestPyPI":
+    for index_dir in PYPI_INDEX_DIRS:
+        index_name = "TestPyPI" if index_dir == "testpypi" else "PyPI"
+        if index_dir == "testpypi":
             console.print(
                 Panel(
                     "[bold yellow]WARNING: TestPyPI is NOT a production index.[/]",
                     border_style="yellow",
                 )
             )
+        proofs_dir = REPO_ROOT / "proofs" / index_dir
+        if not proofs_dir.is_dir():
+            info(f"{index_name}: no proofs directory (run download_release.py first)")
+            continue
         for name, path in artifacts.items():
-            prov = fetch_pypi_provenance(PACKAGE_NAME, version, name, base_url)
-            if prov:
-                if not verify_pypi_attestation(path, prov, index_name):
-                    failures += 1
-            else:
+            prov_file = proofs_dir / f"{name}.provenance.json"
+            if not prov_file.exists():
                 info(f"{index_name}: no attestation for {name}")
+                continue
+            prov = json.loads(prov_file.read_text())
+            if not verify_pypi_attestation(path, prov, index_name):
+                failures += 1
 
     # -- Summary -------------------------------------------------------
     console.print()

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -532,7 +532,8 @@ def main() -> int:
             )
         proofs_dir = REPO_ROOT / "proofs" / index_dir
         if not proofs_dir.is_dir():
-            info(f"{index_name}: no proofs directory (run download_release.py first)")
+            fail(f"{index_name}: no proofs directory (run download_release.py first)")
+            failures += 1
             continue
         for name, path in artifacts.items():
             prov_file = proofs_dir / f"{name}.provenance.json"
@@ -540,8 +541,8 @@ def main() -> int:
                 info(f"{index_name}: no attestation for {name}")
                 continue
             try:
-                prov = json.loads(prov_file.read_text())
-            except (OSError, json.JSONDecodeError) as exc:
+                prov = json.loads(prov_file.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
                 fail(f"{index_name}: invalid provenance for {name}: {exc}")
                 failures += 1
                 continue

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -721,7 +721,12 @@ def main() -> int:
             if not prov_file.exists():
                 info(f"{index_name}: no attestation for {name}")
                 continue
-            prov = json.loads(prov_file.read_text())
+            try:
+                prov = json.loads(prov_file.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                fail(f"{index_name}: invalid provenance for {name}: {exc}")
+                failures += 1
+                continue
             if not verify_pypi_attestation(path, prov, index_name, version):
                 failures += 1
 

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -33,9 +33,7 @@ import subprocess
 import sys
 import tempfile
 import tomllib
-import urllib.error
 import urllib.parse
-import urllib.request
 from pathlib import Path
 
 from rich.console import Console
@@ -475,33 +473,13 @@ def print_slsa_provenance(data: dict) -> None:
 
 # -- 5. PyPI attestations (PEP 740) ------------------------------------
 
-PYPI_INDEXES = [
-    ("PyPI", "https://pypi.org"),
-    ("TestPyPI", "https://test.pypi.org"),
-]
+PYPI_INDEX_DIRS = ["pypi", "testpypi"]
 
 
 def _ensure_proofs_dir() -> Path:
     proofs = REPO_ROOT / "proofs"
     proofs.mkdir(exist_ok=True)
     return proofs
-
-
-def fetch_pypi_provenance(
-    package: str,
-    version: str,
-    filename: str,
-    base_url: str,
-) -> dict | None:
-    url = f"{base_url}/integrity/{package}/{version}/{filename}/provenance"
-    if not url.startswith(("https://pypi.org/", "https://test.pypi.org/")):
-        return None
-    try:
-        req = urllib.request.Request(url)  # noqa: S310 — URL validated above
-        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
-            return json.loads(resp.read())
-    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError):
-        return None
 
 
 def extract_attestation_file(
@@ -640,19 +618,6 @@ def verify_pypi_attestation(
     return True
 
 
-def save_provenance_to_proofs(
-    provenance: dict,
-    filename: str,
-    index_name: str,
-) -> None:
-    index_dir = "testpypi" if index_name == "TestPyPI" else "pypi"
-    proofs_dir = _ensure_proofs_dir() / index_dir
-    proofs_dir.mkdir(exist_ok=True)
-    out = proofs_dir / f"{filename}.provenance.json"
-    out.write_text(json.dumps(provenance, indent=2))
-    info(f"Saved to {out.relative_to(REPO_ROOT)}")
-
-
 # -- Main --------------------------------------------------------------
 
 
@@ -732,10 +697,11 @@ def main() -> int:
     # -- 5. PyPI / TestPyPI attestations (PEP 740) ---------------------
     header("5. PyPI / TestPyPI attestations (PEP 740)")
     explain("pypi_attestation")
-    for index_name, base_url in PYPI_INDEXES:
-        header(f"5.{PYPI_INDEXES.index((index_name, base_url)) + 1} {index_name}")
+    for idx, index_dir in enumerate(PYPI_INDEX_DIRS, 1):
+        index_name = "TestPyPI" if index_dir == "testpypi" else "PyPI"
+        header(f"5.{idx} {index_name}")
 
-        if index_name == "TestPyPI":
+        if index_dir == "testpypi":
             console.print(
                 Panel(
                     "[bold yellow]WARNING: TestPyPI is NOT a production index.[/]\n"
@@ -745,14 +711,19 @@ def main() -> int:
                 )
             )
 
+        proofs_dir = REPO_ROOT / "proofs" / index_dir
+        if not proofs_dir.is_dir():
+            info(f"{index_name}: no proofs directory (run download_release.py first)")
+            continue
+
         for name, path in artifacts.items():
-            prov = fetch_pypi_provenance(PACKAGE_NAME, version, name, base_url)
-            if prov:
-                save_provenance_to_proofs(prov, name, index_name)
-                if not verify_pypi_attestation(path, prov, index_name, version):
-                    failures += 1
-            else:
+            prov_file = proofs_dir / f"{name}.provenance.json"
+            if not prov_file.exists():
                 info(f"{index_name}: no attestation for {name}")
+                continue
+            prov = json.loads(prov_file.read_text())
+            if not verify_pypi_attestation(path, prov, index_name, version):
+                failures += 1
 
     # -- Summary -------------------------------------------------------
     console.print()

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -713,7 +713,8 @@ def main() -> int:
 
         proofs_dir = REPO_ROOT / "proofs" / index_dir
         if not proofs_dir.is_dir():
-            info(f"{index_name}: no proofs directory (run download_release.py first)")
+            fail(f"{index_name}: no proofs directory (run download_release.py first)")
+            failures += 1
             continue
 
         for name, path in artifacts.items():
@@ -722,8 +723,8 @@ def main() -> int:
                 info(f"{index_name}: no attestation for {name}")
                 continue
             try:
-                prov = json.loads(prov_file.read_text())
-            except (OSError, json.JSONDecodeError) as exc:
+                prov = json.loads(prov_file.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
                 fail(f"{index_name}: invalid provenance for {name}: {exc}")
                 failures += 1
                 continue

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -496,7 +496,12 @@ def main() -> int:
             if not prov_file.exists():
                 info(f"{index_name}: no attestation for {name}")
                 continue
-            prov = json.loads(prov_file.read_text())
+            try:
+                prov = json.loads(prov_file.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                fail(f"{index_name}: invalid provenance for {name}: {exc}")
+                failures += 1
+                continue
             if not verify_pypi_attestation(path, prov, index_name):
                 failures += 1
 

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -30,9 +30,7 @@ import shutil
 import subprocess
 import sys
 import tomllib
-import urllib.error
 import urllib.parse
-import urllib.request
 from pathlib import Path
 
 from rich.console import Console
@@ -66,10 +64,7 @@ OIDC_ISSUER = KNOWN_HOSTS[_repo_host]
 RELEASE_WORKFLOW = "release.yml"
 TAG_PREFIX = "v"  # tags are formatted as v{version}, e.g. v0.4.2a7
 
-PYPI_INDEXES = [
-    ("PyPI", "https://pypi.org"),
-    ("TestPyPI", "https://test.pypi.org"),
-]
+PYPI_INDEX_DIRS = ["pypi", "testpypi"]
 
 
 # -- Helpers -----------------------------------------------------------
@@ -101,12 +96,6 @@ def collect_local(version: str) -> dict[str, Path]:
     return {
         f.name: f for f in sorted(dist_dir.iterdir()) if is_dist_file(f.name) and version in f.name
     }
-
-
-def _ensure_proofs_dir() -> Path:
-    proofs = REPO_ROOT / "proofs"
-    proofs.mkdir(exist_ok=True)
-    return proofs
 
 
 def header(title: str) -> None:
@@ -294,23 +283,6 @@ def verify_slsa_provenance(path: Path, provenance_path: Path, version: str) -> b
 
 
 # -- 4. PyPI attestations (PEP 740) ------------------------------------
-
-
-def fetch_pypi_provenance(
-    package: str,
-    version: str,
-    filename: str,
-    base_url: str,
-) -> dict | None:
-    url = f"{base_url}/integrity/{package}/{version}/{filename}/provenance"
-    if not url.startswith(("https://pypi.org/", "https://test.pypi.org/")):
-        return None
-    try:
-        req = urllib.request.Request(url)  # noqa: S310 — URL validated above
-        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310
-            return json.loads(resp.read())
-    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError):
-        return None
 
 
 def verify_pypi_attestation(path: Path, provenance: dict, index_name: str) -> bool:
@@ -506,26 +478,27 @@ def main() -> int:
 
     # -- 5. PyPI / TestPyPI attestations (PEP 740) ---------------------
     header("5. PyPI / TestPyPI attestations (pypi-attestations library)")
-    for index_name, base_url in PYPI_INDEXES:
-        if index_name == "TestPyPI":
+    for index_dir in PYPI_INDEX_DIRS:
+        index_name = "TestPyPI" if index_dir == "testpypi" else "PyPI"
+        if index_dir == "testpypi":
             console.print(
                 Panel(
                     "[bold yellow]WARNING: TestPyPI is NOT a production index.[/]",
                     border_style="yellow",
                 )
             )
-        index_dir = "testpypi" if index_name == "TestPyPI" else "pypi"
-        proofs_dir = _ensure_proofs_dir() / index_dir
-        proofs_dir.mkdir(exist_ok=True)
+        proofs_dir = REPO_ROOT / "proofs" / index_dir
+        if not proofs_dir.is_dir():
+            info(f"{index_name}: no proofs directory (run download_release.py first)")
+            continue
         for name, path in artifacts.items():
-            prov = fetch_pypi_provenance(PACKAGE_NAME, version, name, base_url)
-            if prov:
-                out = proofs_dir / f"{name}.provenance.json"
-                out.write_text(json.dumps(prov, indent=2))
-                if not verify_pypi_attestation(path, prov, index_name):
-                    failures += 1
-            else:
+            prov_file = proofs_dir / f"{name}.provenance.json"
+            if not prov_file.exists():
                 info(f"{index_name}: no attestation for {name}")
+                continue
+            prov = json.loads(prov_file.read_text())
+            if not verify_pypi_attestation(path, prov, index_name):
+                failures += 1
 
     # -- Summary -------------------------------------------------------
     console.print()

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -489,7 +489,8 @@ def main() -> int:
             )
         proofs_dir = REPO_ROOT / "proofs" / index_dir
         if not proofs_dir.is_dir():
-            info(f"{index_name}: no proofs directory (run download_release.py first)")
+            fail(f"{index_name}: no proofs directory (run download_release.py first)")
+            failures += 1
             continue
         for name, path in artifacts.items():
             prov_file = proofs_dir / f"{name}.provenance.json"
@@ -497,8 +498,8 @@ def main() -> int:
                 info(f"{index_name}: no attestation for {name}")
                 continue
             try:
-                prov = json.loads(prov_file.read_text())
-            except (OSError, json.JSONDecodeError) as exc:
+                prov = json.loads(prov_file.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
                 fail(f"{index_name}: invalid provenance for {name}: {exc}")
                 failures += 1
                 continue


### PR DESCRIPTION
## Summary

- Remove `fetch_pypi_provenance`, `PYPI_INDEXES`, and `urllib` imports from all three verify scripts
- Verify scripts now read from `proofs/{pypi,testpypi}/` populated by `download_release.py`
- Missing proofs directory is treated as a verification failure (not silently skipped)
- Fix error handling in `download_release.py`: distinguish 404 (expected) from HTTP errors and network failures

Closes #48.

## Test plan

- [x] 158 pytest tests pass
- [x] Pre-commit passes
- [x] `verify_provenance.py 0.4.2a9` reads from proofs/ correctly
- [x] PyPI shows "no attestation" (expected), TestPyPI verifies OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

### Error handling refinement in download_release.py
- fetch_pypi_provenance now treats HTTP 404 (no attestation) as a non-exceptional case and returns None only for 404.
- Non-404 HTTP errors and network or OS-level failures are no longer swallowed: non-404 HTTPError values print a warning and are re-raised; OSError (network-level) prints a warning and is re-raised so callers can distinguish "no attestation" from fetch failures.
- JSONDecodeError from malformed provenance is reported and re-raised.
- extract_pypi_proofs wraps provenance fetches so per-index/per-file OSError and JSONDecodeError produce a per-file “fetch failed” message and raise a RuntimeError rather than being treated as absent attestations.

### Verify scripts now use pre-downloaded local proofs
- verify_cosign.py, verify_provenance.py, and verify_pure.py no longer perform inline PyPI/TestPyPI network fetches and their urllib imports were removed.
- Removed fetch_pypi_provenance and PYPI_INDEXES; verification now iterates PYPI_INDEX_DIRS = ["pypi", "testpypi"] and reads provenance from proofs/{index_dir}/{artifact}.provenance.json.
- If proofs/{index_dir} is missing, the index is skipped with an informational message instructing the user to run download_release.py to populate proofs/.
- If a per-artifact provenance file is missing, the scripts log “no attestation” and continue.
- File I/O and JSON parsing of provenance files are guarded: read/parse failures are logged as invalid provenance, increment failure counters, and the verification run continues rather than crashing the whole run.

### Documentation
- CHANGELOG.md ([Unreleased]) updated:
  - Changed: verify scripts no longer fetch PyPI provenance inline; they read from proofs/{pypi,testpypi}/ populated by download_release.py.
  - Fixed: download_release.py now distinguishes HTTP 404 (no attestation) from other HTTP/network/server errors.

### Tests & CI
- 158 pytest tests pass.
- pre-commit checks pass.
- Manual/functional checks: verify_provenance.py 0.4.2a9 reads from proofs/ correctly; PyPI shows “no attestation” where expected; TestPyPI provenance verifies successfully.

### Reviewer notes
- Behavioral change: network fetching and nuanced error handling moved into download_release.py; verification scripts are now offline consumers of the proofs/ cache. This clarifies the difference between "no attestation" (404) and fetch failures and removes runtime network access during verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->