### PR TITLE
docs: Copilot review means feedback only, not fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,9 +49,14 @@ When bumping version, update ALL of:
 
 ## Review process
 
+**When asked to "review", only review.** Do not create commits, push
+changes, or apply fixes. The goal of a review is to provide feedback,
+not to modify the code. If you find issues, report them as review
+comments — never fix them on behalf of the author.
+
 When reviewing PRs:
 - Triage every comment, including low-confidence hidden ones
-- For actionable findings: fix in the PR or create a GitHub issue and link it
+- For actionable findings: report them as comments, or create a GitHub issue and link it
 - Never dismiss comments without explicit owner confirmation
 - Reply with linked issue number or reason before resolving conversations
 - After changes are made, re-review before approving

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,7 +56,7 @@ comments — never fix them on behalf of the author.
 
 When reviewing PRs:
 - Triage every comment, including low-confidence hidden ones
-- For actionable findings: report them as comments, or create a GitHub issue and link it
+- For actionable findings: report them as review comments (with code suggestions where applicable), or create a GitHub issue and link it
 - Never dismiss comments without explicit owner confirmation
 - Reply with linked issue number or reason before resolving conversations
 - After changes are made, re-review before approving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 - Switch Dependabot from `pip` to `uv` ecosystem so it updates
   `pyproject.toml` + `uv.lock` directly (#94).
+- Copilot instructions: clarify that "review" means feedback only,
+  not committing fixes on behalf of the author.
 
 ## [0.4.2a9] - 2026-04-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,9 +134,9 @@ downloading proofs via `download_release.py`):
 
 Proof files: `proofs/{github,pypi}/`. Distribution files: `dist/`.
 
-## Pull request review process
+## Pull request review process (author checklist)
 
-After creating a PR:
+After creating a PR, the **author** (you, as the coding agent) must:
 
 1. **Request AI reviews** on every PR (Copilot, Gemini Code Assist, CodeRabbit).
 2. **Triage every review comment**, including low-confidence hidden ones.


### PR DESCRIPTION
## Summary

- Clarify in Copilot instructions that "review" means providing feedback as comments, not creating commits or applying fixes on behalf of the author.
- Update actionable findings guidance: report as comments instead of fixing in the PR.
- Add CHANGELOG entry under [Unreleased].

## Test plan

- [ ] Verify Copilot respects the updated instructions on next review request
- [ ] Confirm CHANGELOG entry renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates Copilot instructions to clarify the scope of the "review" action and modifies actionable findings guidance accordingly. The changes are documentation-only and applied to two files: `.github/copilot-instructions.md` and `CHANGELOG.md`.

## Changes

**`.github/copilot-instructions.md`**

Updated the "Review process" section to explicitly state that when asked to "review", the reviewer should only provide feedback and never create commits, push changes, or apply fixes on behalf of the author. Issues should be reported as review comments rather than being fixed directly in the PR.

Modified actionable findings guidance to report issues as comments or create GitHub issues, removing the previous option to "fix in the PR."

**`CHANGELOG.md`**

Added an entry under `[Unreleased] > Changed` documenting that Copilot instructions were clarified to specify that "review" means feedback only, not committing fixes on behalf of the author.

## Notes

- All changes are documentation-only; no functional code modifications
- CHANGELOG entry included as required by project conventions
- Aligns with the project's instruction that AI reviewers should not modify code during reviews

<!-- end of auto-generated comment: release notes by coderabbit.ai -->