### PR TITLE
revert: Bump rich from 14.3.3 to 15.0.0 (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ## [Unreleased]
 
-### Changed
-
-- Bump rich from 14.3.3 to 15.0.0.
-
 ## [0.4.2a9] - 2026-04-12
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Revert the no-op merge of #91 (Dependabot rich 15.0.0 bump)
- Rich 15.0.0 is incompatible: `sigstore` 4.2.0 (via `pypi-attestations`) requires `rich>=13,<15`
- The original PR only updated `requirements*.txt` without `pyproject.toml`/`uv.lock`, so the regen clobbered the changes — the merge was effectively a no-op with a misleading changelog entry

## Test plan

- [ ] Verify `uv.lock` still has rich 14.3.3
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reverts PR #91, which bumped rich from 14.3.3 to 15.0.0. The revert is necessary because rich 15.0.0 is incompatible with sigstore 4.2.0 (which requires `rich>=13,<15` via pypi-attestations).

The original PR #91 had only updated `requirements.txt` without updating `pyproject.toml` or `uv.lock`, making the merge effectively a no-op while adding a misleading changelog entry. This PR removes that changelog entry, restoring the previous state with rich 14.3.3 locked in `uv.lock`.

## Changes

- **CHANGELOG.md**: Removed the "Bump rich from 14.3.3 to 15.0.0" entry from the `[Unreleased]` section

## Files Changed

- CHANGELOG.md (−4 lines)

## Supply-chain Impact

Maintains compliance with sigstore/pypi-attestations dependency constraints by keeping rich at 14.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->