### PR TITLE
chore: switch Dependabot from pip to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 
 updates:
-  # Python dependencies managed by uv
-  - package-ecosystem: "pip"
+  # Python dependencies (uv ecosystem — updates pyproject.toml + uv.lock)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/dependabot-regen.yml
+++ b/.github/workflows/dependabot-regen.yml
@@ -1,0 +1,66 @@
+# Companion workflow for Dependabot uv PRs.
+#
+# Dependabot (uv ecosystem) updates pyproject.toml + uv.lock but cannot
+# run post-update commands.  This workflow regenerates the derived
+# requirements*.txt files and commits them back to the PR branch.
+#
+# Uses GITHUB_TOKEN to push.  If the pushed commit does not retrigger CI
+# (a known GitHub limitation with GITHUB_TOKEN), upgrade to a GitHub App
+# token or PAT — see docs/dependabot-token-upgrade.md (TODO).
+
+name: "Dependabot: regenerate requirements"
+
+on:
+  pull_request:
+    paths:
+      - pyproject.toml
+      - uv.lock
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+concurrency:
+  group: dependabot-regen-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  regen:
+    name: Regenerate requirements
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v4.2.0
+        with:
+          enable-cache: true
+
+      - run: uv sync --frozen --dev
+
+      - name: Regenerate requirements files
+        run: uv run python scripts/regen_requirements.py
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet requirements.txt requirements-dev.txt; then
+            echo "Requirements files are up to date — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add requirements.txt requirements-dev.txt
+          git commit -m "chore(deps): regenerate requirements from uv.lock"
+          git push

--- a/.github/workflows/dependabot-regen.yml
+++ b/.github/workflows/dependabot-regen.yml
@@ -5,8 +5,8 @@
 # requirements*.txt files and commits them back to the PR branch.
 #
 # Uses GITHUB_TOKEN to push.  If the pushed commit does not retrigger CI
-# (a known GitHub limitation with GITHUB_TOKEN), upgrade to a GitHub App
-# token or PAT — see docs/dependabot-token-upgrade.md (TODO).
+# (a known GitHub limitation with GITHUB_TOKEN), switch to a GitHub App
+# token or fine-grained PAT for the checkout/push steps.
 
 name: "Dependabot: regenerate requirements"
 
@@ -50,8 +50,12 @@ jobs:
 
       - run: uv sync --frozen --dev
 
-      - name: Regenerate requirements files
-        run: uv run python scripts/regen_requirements.py
+      - name: Export requirements from uv.lock
+        run: |
+          uv export --format requirements-txt --no-emit-project --no-dev \
+            --output-file requirements.txt
+          uv export --format requirements-txt --no-emit-project \
+            --output-file requirements-dev.txt
 
       - name: Commit and push if changed
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ## [Unreleased]
 
+### Changed
+
+- Switch Dependabot from `pip` to `uv` ecosystem so it updates
+  `pyproject.toml` + `uv.lock` directly (#94).
+
+### Added
+
+- Companion workflow (`dependabot-regen.yml`) that auto-regenerates
+  `requirements*.txt` after Dependabot updates dependencies.
+
 ## [0.4.2a9] - 2026-04-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,15 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ## [Unreleased]
 
-### Changed
-
-- Switch Dependabot from `pip` to `uv` ecosystem so it updates
-  `pyproject.toml` + `uv.lock` directly (#94).
-
 ### Added
 
 - Companion workflow (`dependabot-regen.yml`) that auto-regenerates
   `requirements*.txt` after Dependabot updates dependencies.
+
+### Changed
+
+- Switch Dependabot from `pip` to `uv` ecosystem so it updates
+  `pyproject.toml` + `uv.lock` directly (#94).
 
 ## [0.4.2a9] - 2026-04-12
 


### PR DESCRIPTION
## Summary

Fixes #94.

- Switch `package-ecosystem` from `"pip"` to `"uv"` so Dependabot updates `pyproject.toml` + `uv.lock` directly instead of only `requirements*.txt`
- Add companion workflow (`dependabot-regen.yml`) that auto-regenerates `requirements*.txt` after Dependabot bumps dependencies
- Previous Dependabot PRs (#88, #90, #91) were all broken/reverted because the `pip` ecosystem couldn't properly update uv-managed projects

### Companion workflow details

- Triggers on Dependabot PRs that touch `pyproject.toml` or `uv.lock`
- Runs `uv run python scripts/regen_requirements.py` to regenerate derived files
- Auto-commits and pushes if requirements changed
- Uses `GITHUB_TOKEN` initially; can be upgraded to a GitHub App token if CI retrigger is needed

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, trigger a Dependabot update (`@dependabot recreate`)
- [ ] Verify Dependabot PR updates `pyproject.toml` + `uv.lock`
- [ ] Verify companion workflow fires and commits regenerated `requirements*.txt`
- [ ] Verify CI passes on the Dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Switches Dependabot from the `pip` ecosystem to the `uv` ecosystem, addressing broken/reverted dependency update PRs (#88, #90, #91). Includes a companion GitHub Actions workflow to auto-regenerate derived requirements files after Dependabot updates.

## Changes

### `.github/dependabot.yml` (new file)
Configures Dependabot to use the `uv` package ecosystem so it updates `pyproject.toml` and `uv.lock` directly (the source of truth for this project). Maintains existing scheduling (weekly on Monday at 06:00 UTC) and Conventional Commit prefixes (`chore(deps)`, `chore(deps-dev)`), with separate grouping for production and development dependencies (minor/patch updates only). Sets PR limit to 10 and applies `dependencies` and `python` labels.

### `.github/workflows/dependabot-regen.yml` (new file)
Companion workflow triggered on `pull_request` events when Dependabot modifies `pyproject.toml` or `uv.lock`. Runs only for `dependabot[bot]` with concurrency control (cancels in-progress runs for the same PR). Checks out the PR head branch, sets up `uv` with caching enabled, runs `uv sync --frozen --dev`, executes `uv run python scripts/regen_requirements.py` to regenerate `requirements*.txt`, and conditionally commits and pushes changes if the requirements files differ. Uses `GITHUB_TOKEN` for authentication. All workflow actions pinned by SHA: `step-security/harden-runner@f808768d...`, `actions/checkout@de0fac2e...`, `astral-sh/setup-uv@cec208311...`.

### `CHANGELOG.md`
Documents under `[Unreleased]` the switch to the `uv` ecosystem (#94) and the new companion workflow.

## Impact

Resolves the root cause of broken Dependabot PRs: Dependabot now updates the primary dependency sources (pyproject.toml, uv.lock) instead of only updating derived requirements files. The companion workflow ensures requirements*.txt remain consistent and CI passes on dependency update PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->