### PR TITLE
fix: remove duplicate scope from Dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
-      include: "scope"
     groups:
       prod-dependencies:
         dependency-type: "production"
@@ -40,7 +39,6 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     labels:
       - "dependencies"
       - "pre-commit"
@@ -56,7 +54,6 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(ci)"
-      include: "scope"
     groups:
       actions:
         patterns:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 - Switch Dependabot from `pip` to `uv` ecosystem so it updates
   `pyproject.toml` + `uv.lock` directly (#94).
+- Fix duplicate scope in Dependabot commit messages (e.g.
+  `chore(deps)(deps):` → `chore(deps):`).
 - Copilot instructions: clarify that "review" means feedback only,
   not committing fixes on behalf of the author.
 


### PR DESCRIPTION
## Summary

Dependabot PR titles have a duplicate scope like `chore(deps)(deps):` instead
of `chore(deps):`. This happens because `include: "scope"` appends the
dependency type as a second scope after the prefix which already contains one.

Remove `include: "scope"` from all three ecosystem entries (uv, pre-commit,
github-actions).

## Test plan

- [ ] CI passes
- [ ] Next Dependabot PR has correct title format (e.g. `chore(deps): Bump ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Removes duplicate scope from Dependabot commit messages by eliminating the `include: "scope"` configuration that was causing repeated scope identifiers.

## Problem
Dependabot-generated PR titles displayed duplicated scopes (e.g., `chore(deps)(deps):` instead of `chore(deps):`). This occurred because the commit message configuration was appending the dependency type as a second scope after a prefix that already contained that scope.

## Changes
- **`.github/dependabot.yml`**: Removed `include: "scope"` from the commit message configuration for three Dependabot ecosystem entries:
  - `uv` (Python ecosystem)
  - `pre-commit` repositories
  - `github-actions`
  
  All other configuration elements (grouping rules, schedules, limits, labels, patterns) remain unchanged.

- **`CHANGELOG.md`**: Added changelog entry in the `[Unreleased]` section under `### Changed` documenting the fix for duplicate scope formatting in Dependabot commit messages.

## Impact
Dependabot PR titles will now display the correct format with a single scope identifier (e.g., `chore(deps): Bump ...`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->