### PR TITLE
fix: catch ValueError in base64 SLSA provenance decoding (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
   `download_release.py`'s `fetch_pypi_provenance` (#48).
 - Guard `stderr.splitlines()[-1]` against empty/whitespace-only stderr
   to prevent `IndexError` crash in verify scripts (#50).
+- Catch `ValueError` (covers `binascii.Error`) in SLSA provenance
+  base64 decoding to prevent crash on malformed payloads (#56).
 
 ## [0.4.2a9] - 2026-04-12
 

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -232,7 +232,7 @@ def verify_slsa_provenance(path: Path, provenance_path: Path, version: str) -> b
             fail(f"  artifact: {artifact_hash}")
             fail(f"  subjects: {subject_hashes}")
             return False
-    except (KeyError, ValueError, json.JSONDecodeError) as exc:
+    except (KeyError, ValueError, TypeError) as exc:
         fail(f"SLSA L3 provenance: could not verify subject match: {exc}")
         return False
 
@@ -276,8 +276,9 @@ def verify_slsa_provenance(path: Path, provenance_path: Path, version: str) -> b
 
             console.print()
             console.print(table)
-    except (KeyError, ValueError, json.JSONDecodeError) as exc:
-        info(f"  (could not display provenance details: {exc})")
+    except (KeyError, ValueError, TypeError) as exc:
+        fail(f"SLSA L3 provenance: could not parse provenance details: {exc}")
+        return False
 
     return True
 

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -232,7 +232,7 @@ def verify_slsa_provenance(path: Path, provenance_path: Path, version: str) -> b
             fail(f"  artifact: {artifact_hash}")
             fail(f"  subjects: {subject_hashes}")
             return False
-    except (KeyError, json.JSONDecodeError) as exc:
+    except (KeyError, ValueError, json.JSONDecodeError) as exc:
         fail(f"SLSA L3 provenance: could not verify subject match: {exc}")
         return False
 
@@ -276,7 +276,7 @@ def verify_slsa_provenance(path: Path, provenance_path: Path, version: str) -> b
 
             console.print()
             console.print(table)
-    except (KeyError, json.JSONDecodeError) as exc:
+    except (KeyError, ValueError, json.JSONDecodeError) as exc:
         info(f"  (could not display provenance details: {exc})")
 
     return True

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -232,7 +232,7 @@ def verify_slsa_provenance(path: Path, provenance_path: Path, version: str) -> b
             fail(f"  artifact: {artifact_hash}")
             fail(f"  subjects: {subject_hashes}")
             return False
-    except (KeyError, ValueError, TypeError) as exc:
+    except (KeyError, ValueError, TypeError, AttributeError, UnicodeDecodeError) as exc:
         fail(f"SLSA L3 provenance: could not verify subject match: {exc}")
         return False
 
@@ -276,7 +276,7 @@ def verify_slsa_provenance(path: Path, provenance_path: Path, version: str) -> b
 
             console.print()
             console.print(table)
-    except (KeyError, ValueError, TypeError) as exc:
+    except (KeyError, ValueError, TypeError, AttributeError, UnicodeDecodeError) as exc:
         fail(f"SLSA L3 provenance: could not parse provenance details: {exc}")
         return False
 


### PR DESCRIPTION
## Summary

`base64.b64decode()` and `json.loads()` in the SLSA provenance parsing blocks
of `verify_pure.py` can raise several exceptions on malformed payloads that
were not caught, crashing the script.

- Add `ValueError` (covers `binascii.Error` and `json.JSONDecodeError`)
- Add `TypeError` for non-string payloads (e.g. `null` from JSON)
- Add `AttributeError` for `.get()` on non-dict objects
- Add `UnicodeDecodeError` for non-UTF-8 bytes from `base64.b64decode`
- Change provenance display parse failure from `info()` to `fail()` +
  `return False` — if provenance can't be parsed, verification should fail

Closes #56.

## Test plan

- [x] Pre-commit passes
- [x] 158 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)