### PR TITLE
fix: address Copilot review hardening items (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
   `download_release.py`'s `fetch_pypi_provenance` (#48).
 - Guard `stderr.splitlines()[-1]` against empty/whitespace-only stderr
   to prevent `IndexError` crash in verify scripts (#50).
+- Publisher mismatch in verify_provenance.py now fails closed instead
+  of warning and continuing (#71).
+- Tighten cosign identity regexp to match only the release workflow,
+  not any workflow in the repo (#71).
+- Wrap trust anchor derivation from pyproject.toml in try/except with
+  clear error messages across all verify/download scripts (#71).
 - Catch `ValueError` (covers `binascii.Error`) in SLSA provenance
   base64 decoding to prevent crash on malformed payloads (#56).
 

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -39,10 +39,15 @@ KNOWN_HOSTS = {
 
 # -- Trust anchors (derived from pyproject.toml) ---------------------------
 
-_pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
-PACKAGE_NAME = _pyproject["project"]["name"]
-_repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
-_repo_host = _repo_url.hostname
+try:
+    _pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    PACKAGE_NAME = _pyproject["project"]["name"]
+    _repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
+    _repo_host = _repo_url.hostname
+except (FileNotFoundError, tomllib.TOMLDecodeError, KeyError) as exc:
+    print(f"Error: Cannot derive trust anchors from pyproject.toml: {exc}")
+    print("Ensure pyproject.toml exists with [project].name and [project.urls].Repository")
+    sys.exit(1)
 if _repo_host not in KNOWN_HOSTS:
     print(f"Error: Unknown repository host: {_repo_host}")
     print(f"Known hosts: {', '.join(KNOWN_HOSTS)}")
@@ -122,6 +127,7 @@ def download_github_release(version: str) -> bool:
 
 def fetch_gh_attestations(version: str) -> None:
     """Fetch and extract GitHub attestation bundles for each dist file."""
+    print(f"  Fetching GH attestations for {TAG_PREFIX}{version}...")
     gh = shutil.which("gh") or "gh"
     for f in sorted(DIST_DIR.iterdir()):
         if not is_dist_file(f.name):
@@ -234,7 +240,9 @@ def extract_pypi_proofs(version: str) -> None:
                 att_file.write_text(json.dumps(att))
                 print(f"  {index_name}: {f.name} — .publish.attestation extracted")
 
-                # Restructure into cosign-compatible bundle
+                # Restructure into cosign-compatible bundle.
+                # Keys are required by PEP 740 — KeyError is a legitimate
+                # failure indicating a malformed attestation.
                 vm = att.get("verification_material", {})
                 cosign_bundle = {
                     "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -139,7 +139,15 @@ def _extract_san_from_bundle(bundle_path: Path) -> str | None:
         sans = san_val.get_values_for_type(UniformResourceIdentifier)
         if sans:
             return sans[0]
-    except (OSError, ValueError, KeyError, ExtensionNotFound, json.JSONDecodeError) as exc:
+    except (
+        OSError,
+        ValueError,
+        KeyError,
+        TypeError,
+        AttributeError,
+        ExtensionNotFound,
+        json.JSONDecodeError,
+    ) as exc:
         fail(f"  could not parse bundle certificate: {exc}")
         return None
     return None

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -26,15 +26,23 @@ Usage:
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
-import shutil
 import subprocess
 import sys
 import tomllib
 import urllib.parse
 from pathlib import Path
+from typing import cast
 
+from cryptography import x509
+from cryptography.x509 import (
+    ExtensionNotFound,
+    SubjectAlternativeName,
+    UniformResourceIdentifier,
+)
+from cryptography.x509.oid import ExtensionOID
 from rich.console import Console
 from rich.panel import Panel
 
@@ -124,25 +132,16 @@ def _extract_san_from_bundle(bundle_path: Path) -> str | None:
         )
         if not cert_b64:
             return None
-        cert_pem = "-----BEGIN CERTIFICATE-----\n" + cert_b64 + "\n-----END CERTIFICATE-----\n"
-        openssl = shutil.which("openssl")
-        if not openssl:
-            return None
-        result = subprocess.run(  # noqa: S603 — args are list literals, no shell
-            [openssl, "x509", "-noout", "-ext", "subjectAltName"],
-            input=cert_pem,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            return None
-        for line in result.stdout.splitlines():
-            stripped = line.strip()
-            if stripped.startswith("URI:"):
-                return stripped.removeprefix("URI:")
-    except (json.JSONDecodeError, KeyError):
-        pass
+        cert_der = base64.b64decode(cert_b64)
+        cert = x509.load_der_x509_certificate(cert_der)
+        san_ext = cert.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
+        san_val = cast(SubjectAlternativeName, san_ext.value)
+        sans = san_val.get_values_for_type(UniformResourceIdentifier)
+        if sans:
+            return sans[0]
+    except (OSError, ValueError, KeyError, ExtensionNotFound, json.JSONDecodeError) as exc:
+        fail(f"  could not parse bundle certificate: {exc}")
+        return None
     return None
 
 

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -49,10 +49,17 @@ KNOWN_HOSTS = {
 
 # -- Trust anchors (derived from pyproject.toml) ---------------------------
 
-_pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
-PACKAGE_NAME = _pyproject["project"]["name"]
-_repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
-_repo_host = _repo_url.hostname
+try:
+    _pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    PACKAGE_NAME = _pyproject["project"]["name"]
+    _repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
+    _repo_host = _repo_url.hostname
+except (FileNotFoundError, tomllib.TOMLDecodeError, KeyError) as exc:
+    console.print(f"[bold red]Cannot derive trust anchors from pyproject.toml: {exc}[/]")
+    console.print(
+        "[dim]Ensure pyproject.toml exists with [project].name and [project.urls].Repository[/]"
+    )
+    sys.exit(1)
 if _repo_host not in KNOWN_HOSTS:
     console.print(f"[bold red]Unknown repository host: {_repo_host}[/]")
     console.print(f"[dim]Known hosts: {', '.join(KNOWN_HOSTS)}[/]")
@@ -146,7 +153,7 @@ def verify_sigstore_blob(path: Path, bundle: Path, version: str) -> bool:
         ]
     )
     if result.returncode != 0:
-        # Try with regexp fallback
+        # Try with workflow-scoped regexp fallback (any tag, but only release workflow)
         result = run(
             [
                 "cosign",
@@ -154,7 +161,7 @@ def verify_sigstore_blob(path: Path, bundle: Path, version: str) -> bool:
                 "--certificate-oidc-issuer",
                 OIDC_ISSUER,
                 "--certificate-identity-regexp",
-                f"https://github.com/{REPO_SLUG}/",
+                f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@",
                 "--bundle",
                 str(bundle),
                 str(path),
@@ -263,7 +270,12 @@ def verify_gh_attestation(path: Path, gh_proofs: Path, version: str) -> bool:
 
 
 def _restructure_pep740_to_cosign(att: dict) -> dict:
-    """Restructure a PEP 740 attestation into a cosign-compatible sigstore bundle."""
+    """Restructure a PEP 740 attestation into a cosign-compatible sigstore bundle.
+
+    Required PEP 740 keys: verification_material.{certificate, transparency_entries},
+    envelope.{statement, signature}. KeyError on missing keys is intentional —
+    malformed attestations should fail loudly.
+    """
     vm = att.get("verification_material", {})
     return {
         "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
@@ -318,7 +330,7 @@ def verify_pypi_attestation(
                     "--certificate-oidc-issuer",
                     OIDC_ISSUER,
                     "--certificate-identity-regexp",
-                    f"https://github.com/{REPO_SLUG}/",
+                    f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@",
                     "--type",
                     "https://docs.pypi.org/attestations/publish/v1",
                     "--bundle",

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -70,6 +71,11 @@ OIDC_ISSUER = KNOWN_HOSTS[_repo_host]
 # Release conventions — update these if your project uses different values
 RELEASE_WORKFLOW = "release.yml"
 TAG_PREFIX = "v"  # tags are formatted as v{version}, e.g. v0.4.2a7
+# OIDC identity template — {version} is substituted at verification time
+IDENTITY_TEMPLATE = (
+    f"https://github.com/{REPO_SLUG}"
+    f"/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{{version}}"
+)
 
 PYPI_INDEX_DIRS = ["pypi", "testpypi"]
 
@@ -109,6 +115,51 @@ def collect_local(version: str) -> dict[str, Path]:
     }
 
 
+def _extract_san_from_bundle(bundle_path: Path) -> str | None:
+    """Extract the SAN URI from a sigstore bundle's signing certificate."""
+    try:
+        bundle_data = json.loads(bundle_path.read_text(encoding="utf-8"))
+        cert_b64 = (
+            bundle_data.get("verificationMaterial", {}).get("certificate", {}).get("rawBytes", "")
+        )
+        if not cert_b64:
+            return None
+        cert_pem = "-----BEGIN CERTIFICATE-----\n" + cert_b64 + "\n-----END CERTIFICATE-----\n"
+        openssl = shutil.which("openssl")
+        if not openssl:
+            return None
+        result = subprocess.run(  # noqa: S603 — args are list literals, no shell
+            [openssl, "x509", "-noout", "-ext", "subjectAltName"],
+            input=cert_pem,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        for line in result.stdout.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("URI:"):
+                return stripped.removeprefix("URI:")
+    except (json.JSONDecodeError, KeyError):
+        pass
+    return None
+
+
+def _verify_bundle_identity(bundle_path: Path, expected_identity: str, label: str) -> bool:
+    """Extract SAN from bundle and compare against expected identity. Returns False on failure."""
+    san = _extract_san_from_bundle(bundle_path)
+    if not san:
+        fail(f"{label}: could not extract SAN from bundle certificate")
+        return False
+    if san != expected_identity:
+        fail(f"{label}: identity mismatch")
+        fail(f"  certificate SAN: {san}")
+        fail(f"  expected: {expected_identity}")
+        return False
+    return True
+
+
 def header(title: str) -> None:
     console.print()
     console.rule(f"[bold blue]{title}[/]")
@@ -136,8 +187,10 @@ def verify_sigstore_blob(path: Path, bundle: Path, version: str) -> bool:
         info(f"No sigstore bundle for {path.name}")
         return True  # not a failure, just not available
 
-    # Use exact identity for the specific tag
-    identity = f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
+    # Extract and verify identity from bundle certificate before cosign check
+    identity = IDENTITY_TEMPLATE.format(version=version)
+    if not _verify_bundle_identity(bundle, identity, f"cosign verify-blob: {path.name}"):
+        return False
 
     result = run(
         [
@@ -152,21 +205,6 @@ def verify_sigstore_blob(path: Path, bundle: Path, version: str) -> bool:
             str(path),
         ]
     )
-    if result.returncode != 0:
-        # Try with workflow-scoped regexp fallback (any tag, but only release workflow)
-        result = run(
-            [
-                "cosign",
-                "verify-blob",
-                "--certificate-oidc-issuer",
-                OIDC_ISSUER,
-                "--certificate-identity-regexp",
-                f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@",
-                "--bundle",
-                str(bundle),
-                str(path),
-            ]
-        )
 
     artifact_hash = sha256(path)
     if result.returncode != 0:
@@ -239,7 +277,10 @@ def verify_gh_attestation(path: Path, gh_proofs: Path, version: str) -> bool:
             fail(f"Could not parse GH attestation: {exc}")
             return False
 
-    identity = f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
+    identity = IDENTITY_TEMPLATE.format(version=version)
+    if not _verify_bundle_identity(bundle_file, identity, f"cosign GH attestation: {path.name}"):
+        return False
+
     result = run(
         [
             "cosign",
@@ -296,6 +337,7 @@ def verify_pypi_attestation(
     path: Path,
     provenance: dict,
     index_name: str,
+    version: str,
 ) -> bool:
     """Verify PyPI PEP 740 attestation using cosign + pypi-attestations inspect."""
     index_dir = "testpypi" if index_name == "TestPyPI" else "pypi"
@@ -323,14 +365,21 @@ def verify_pypi_attestation(
             if not att_file.exists():
                 att_file.write_text(json.dumps(att))
 
+            identity = IDENTITY_TEMPLATE.format(version=version)
+            if not _verify_bundle_identity(
+                bundle_file, identity, f"cosign {index_name} PEP 740: {path.name}"
+            ):
+                all_ok = False
+                continue
+
             result = run(
                 [
                     "cosign",
                     "verify-blob-attestation",
                     "--certificate-oidc-issuer",
                     OIDC_ISSUER,
-                    "--certificate-identity-regexp",
-                    f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@",
+                    "--certificate-identity",
+                    identity,
                     "--type",
                     "https://docs.pypi.org/attestations/publish/v1",
                     "--bundle",
@@ -558,7 +607,7 @@ def main() -> int:
                 fail(f"{index_name}: invalid provenance for {name}: {exc}")
                 failures += 1
                 continue
-            if not verify_pypi_attestation(path, prov, index_name):
+            if not verify_pypi_attestation(path, prov, index_name, version):
                 failures += 1
 
     # -- Summary -------------------------------------------------------

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -260,8 +260,9 @@ def _extract_san_from_bundle(bundle_path: Path) -> str | None:
             stripped = line.strip()
             if stripped.startswith("URI:"):
                 return stripped.removeprefix("URI:")
-    except (json.JSONDecodeError, KeyError):
-        pass
+    except (json.JSONDecodeError, KeyError) as exc:
+        console.print(f"  [dim]could not parse bundle certificate: {exc}[/]")
+        return None
     return None
 
 

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -252,16 +252,18 @@ def _extract_san_from_bundle(bundle_path: Path) -> str | None:
         cert_pem = "-----BEGIN CERTIFICATE-----\n" + cert_b64 + "\n-----END CERTIFICATE-----\n"
         openssl = shutil.which("openssl")
         if not openssl:
+            fail("  openssl not found — required for SAN extraction")
             return None
         result = run([openssl, "x509", "-noout", "-ext", "subjectAltName"], input=cert_pem)
         if result.returncode != 0:
+            fail(f"  openssl x509 failed: {result.stderr.strip()}")
             return None
         for line in result.stdout.splitlines():
             stripped = line.strip()
             if stripped.startswith("URI:"):
                 return stripped.removeprefix("URI:")
-    except (json.JSONDecodeError, KeyError) as exc:
-        console.print(f"  [dim]could not parse bundle certificate: {exc}[/]")
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as exc:
+        fail(f"  could not parse bundle certificate: {exc}")
         return None
     return None
 

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -73,6 +73,11 @@ OIDC_ISSUER = KNOWN_HOSTS[_repo_host]
 # Release conventions — update these if your project uses different values
 RELEASE_WORKFLOW = "release.yml"
 TAG_PREFIX = "v"  # tags are formatted as v{version}, e.g. v0.4.2a7
+# OIDC identity template — {version} is substituted at verification time
+IDENTITY_TEMPLATE = (
+    f"https://github.com/{REPO_SLUG}"
+    f"/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{{version}}"
+)
 
 # -- Descriptions for each mechanism ----------------------------------
 
@@ -245,7 +250,10 @@ def _extract_san_from_bundle(bundle_path: Path) -> str | None:
         if not cert_b64:
             return None
         cert_pem = "-----BEGIN CERTIFICATE-----\n" + cert_b64 + "\n-----END CERTIFICATE-----\n"
-        result = run(["openssl", "x509", "-noout", "-ext", "subjectAltName"], input=cert_pem)
+        openssl = shutil.which("openssl")
+        if not openssl:
+            return None
+        result = run([openssl, "x509", "-noout", "-ext", "subjectAltName"], input=cert_pem)
         if result.returncode != 0:
             return None
         for line in result.stdout.splitlines():
@@ -262,9 +270,16 @@ def verify_sigstore(path: Path, bundle: Path | None, version: str) -> bool:
         info(f"sigstore: no bundle for {path.name}")
         return True
 
+    expected_identity = IDENTITY_TEMPLATE.format(version=version)
     san = _extract_san_from_bundle(bundle)
     if not san:
-        san = f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
+        fail(f"sigstore: could not extract SAN from bundle for {path.name}")
+        return False
+    if san != expected_identity:
+        fail(f"sigstore: identity mismatch for {path.name}")
+        fail(f"  certificate SAN: {san}")
+        fail(f"  expected: {expected_identity}")
+        return False
 
     result = run(
         [
@@ -555,10 +570,7 @@ def verify_pypi_attestation(
 
     # Use local trust anchors for identity — never relax to provenance publisher data
     publisher_data = bundles[0].get("publisher", {})
-    identity = (
-        f"https://github.com/{REPO_SLUG}"
-        f"/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
-    )
+    identity = IDENTITY_TEMPLATE.format(version=version)
 
     # Fail closed on publisher mismatch — do not continue verification
     pub_repo = publisher_data.get("repository", "")

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -338,9 +338,9 @@ def verify_gh_attestation(path: Path) -> dict | None:
             att_file.write_text(json.dumps(records, indent=2))
             info(f"Saved to {att_file.relative_to(REPO_ROOT)}")
             return records[0]
-    except json.JSONDecodeError:
-        pass
-    return None
+    except json.JSONDecodeError as exc:
+        fail(f"  could not parse gh attestation output: {exc}")
+        raise
 
 
 def print_gh_attestation_details(attestation: dict) -> None:
@@ -441,11 +441,14 @@ def verify_slsa_provenance(artifact: Path, provenance: Path, version: str) -> bo
 
     for line in result.stdout.splitlines():
         try:
-            print_slsa_provenance(json.loads(line))
-            break
+            provenance = json.loads(line)
         except json.JSONDecodeError:
-            continue
-    return True
+            continue  # scan for first valid JSON line in slsa-verifier output
+        else:
+            print_slsa_provenance(provenance)
+            return True
+    fail(f"  could not parse provenance from slsa-verifier output for {artifact.name}")
+    return False
 
 
 def print_slsa_provenance(data: dict) -> None:

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -342,7 +342,7 @@ def verify_gh_attestation(path: Path) -> dict | None:
             return records[0]
     except json.JSONDecodeError as exc:
         fail(f"  could not parse gh attestation output: {exc}")
-        raise
+    return None
 
 
 def print_gh_attestation_details(attestation: dict) -> None:
@@ -443,11 +443,11 @@ def verify_slsa_provenance(artifact: Path, provenance: Path, version: str) -> bo
 
     for line in result.stdout.splitlines():
         try:
-            provenance = json.loads(line)
+            provenance_data = json.loads(line)
         except json.JSONDecodeError:
             continue  # scan for first valid JSON line in slsa-verifier output
         else:
-            print_slsa_provenance(provenance)
+            print_slsa_provenance(provenance_data)
             return True
     fail(f"  could not parse provenance from slsa-verifier output for {artifact.name}")
     return False

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -52,10 +52,17 @@ KNOWN_HOSTS = {
 
 # -- Trust anchors (derived from pyproject.toml) ---------------------------
 
-_pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
-PACKAGE_NAME = _pyproject["project"]["name"]
-_repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
-_repo_host = _repo_url.hostname
+try:
+    _pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    PACKAGE_NAME = _pyproject["project"]["name"]
+    _repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
+    _repo_host = _repo_url.hostname
+except (FileNotFoundError, tomllib.TOMLDecodeError, KeyError) as exc:
+    console.print(f"[bold red]Cannot derive trust anchors from pyproject.toml: {exc}[/]")
+    console.print(
+        "[dim]Ensure pyproject.toml exists with [project].name and [project.urls].Repository[/]"
+    )
+    sys.exit(1)
 if _repo_host not in KNOWN_HOSTS:
     console.print(f"[bold red]Unknown repository host: {_repo_host}[/]")
     console.print(f"[dim]Known hosts: {', '.join(KNOWN_HOSTS)}[/]")
@@ -553,13 +560,15 @@ def verify_pypi_attestation(
         f"/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
     )
 
-    # Warn if publisher data doesn't match trust anchors
+    # Fail closed on publisher mismatch — do not continue verification
     pub_repo = publisher_data.get("repository", "")
     pub_wf = publisher_data.get("workflow", "")
     if pub_repo and pub_repo != REPO_SLUG:
         fail(f"Publisher repo mismatch: {pub_repo} != {REPO_SLUG}")
+        return False
     if pub_wf and pub_wf != RELEASE_WORKFLOW:
         fail(f"Publisher workflow mismatch: {pub_wf} != {RELEASE_WORKFLOW}")
+        return False
 
     # Verify with pypi-attestations CLI
     # CLI expects {artifact}.publish.attestation next to the artifact,

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -138,6 +138,36 @@ def info(msg: str) -> None:
     console.print(f"  [dim]{msg}[/]")
 
 
+def _extract_san(bundle: Bundle) -> str | None:
+    """Extract the SAN URI from a sigstore Bundle's signing certificate."""
+    try:
+        cert = bundle.signing_certificate
+        san_ext = cert.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
+        san_val = cast(SubjectAlternativeName, san_ext.value)
+        sans = san_val.get_values_for_type(UniformResourceIdentifier)
+        return sans[0] if sans else None
+    except (ValueError, KeyError, ExtensionNotFound, TypeError, AttributeError) as exc:
+        fail(f"  could not extract SAN from certificate: {exc}")
+        return None
+
+
+def _verify_identity(bundle: Bundle, expected_identity: str, label: str) -> bool:
+    """Extract SAN from bundle and compare against expected identity.
+
+    Returns True if SAN matches, False (with logged error) otherwise.
+    """
+    actual = _extract_san(bundle)
+    if not actual:
+        fail(f"{label}: no SAN URI in signing certificate")
+        return False
+    if actual != expected_identity:
+        fail(f"{label}: identity mismatch")
+        fail(f"  certificate SAN: {actual}")
+        fail(f"  expected: {expected_identity}")
+        return False
+    return True
+
+
 # -- 1. SHA256 checksums -----------------------------------------------
 
 
@@ -184,24 +214,7 @@ def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
         return False
 
     # Extract SAN from certificate and compare against expected identity
-    try:
-        cert = bundle.signing_certificate
-        san_ext = cert.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
-        san_val = cast(SubjectAlternativeName, san_ext.value)
-        sans = san_val.get_values_for_type(UniformResourceIdentifier)
-        if not sans:
-            fail(f"sigstore verify: {path.name}")
-            fail("  error: no SAN URI in signing certificate")
-            return False
-        actual_identity = sans[0]
-        if actual_identity != expected_identity:
-            fail(f"sigstore verify: {path.name}")
-            fail(f"  identity mismatch: {actual_identity}")
-            fail(f"  expected: {expected_identity}")
-            return False
-    except (ValueError, KeyError, ExtensionNotFound) as exc:
-        fail(f"sigstore verify: {path.name}")
-        fail(f"  error: could not extract SAN from certificate: {exc}")
+    if not _verify_identity(bundle, expected_identity, f"sigstore verify: {path.name}"):
         return False
 
     # Cryptographic verification with sigstore library
@@ -217,7 +230,7 @@ def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
         return False
 
     ok(f"sigstore verify: {path.name} ({sha256(path)})")
-    info(f"  signed by: {actual_identity}")
+    info(f"  signed by: {expected_identity}")
     info(f"  trust root: {OIDC_ISSUER}")
     return True
 
@@ -461,16 +474,18 @@ def main() -> int:
                 info(f"Empty GH attestation for {name}")
                 continue
             bundle_json = json.dumps(data[0]["attestation"]["bundle"]).encode()
+            expected_id = IDENTITY_TEMPLATE.format(version=version)
 
             bundle = Bundle.from_json(bundle_json)
+
+            # Extract and verify SAN from certificate
+            if not _verify_identity(bundle, expected_id, f"GH attestation: {name}"):
+                failures += 1
+                continue
+
+            # Cryptographic verification
             verifier = Verifier.production()
-            identity = policy.Identity(
-                identity=(
-                    f"https://github.com/{REPO_SLUG}"
-                    f"/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
-                ),
-                issuer=OIDC_ISSUER,
-            )
+            identity = policy.Identity(identity=expected_id, issuer=OIDC_ISSUER)
             verifier.verify_dsse(bundle, identity)
 
             # verify_dsse checks signature but NOT artifact digest match
@@ -487,7 +502,7 @@ def main() -> int:
                 continue
 
             ok(f"GH attestation verified: {name} ({artifact_hash})")
-            info(f"  signed by: {RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}")
+            info(f"  signed by: {expected_id}")
             info(f"  trust root: {OIDC_ISSUER}")
         except (
             sigstore.errors.VerificationError,

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -63,6 +63,11 @@ OIDC_ISSUER = KNOWN_HOSTS[_repo_host]
 # Release conventions — update these if your project uses different values
 RELEASE_WORKFLOW = "release.yml"
 TAG_PREFIX = "v"  # tags are formatted as v{version}, e.g. v0.4.2a7
+# OIDC identity template — {version} is substituted at verification time
+IDENTITY_TEMPLATE = (
+    f"https://github.com/{REPO_SLUG}"
+    f"/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{{version}}"
+)
 
 PYPI_INDEX_DIRS = ["pypi", "testpypi"]
 
@@ -156,22 +161,16 @@ def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
     from sigstore.models import Bundle
     from sigstore.verify import Verifier, policy
 
-    identity_str = f"https://github.com/{REPO_SLUG}/.github/workflows/{RELEASE_WORKFLOW}@refs/tags/{TAG_PREFIX}{version}"
+    expected_identity = IDENTITY_TEMPLATE.format(version=version)
 
     try:
         bundle = Bundle.from_json(bundle_path.read_bytes())
-        verifier = Verifier.production()
-        identity = policy.Identity(identity=identity_str, issuer=OIDC_ISSUER)
-        verifier.verify_artifact(path.read_bytes(), bundle, identity)
-    except (sigstore.errors.VerificationError, ValueError, OSError) as exc:
-        artifact_hash = sha256(path)
+    except (ValueError, OSError) as exc:
         fail(f"sigstore verify: {path.name}")
-        fail(f"  artifact: {artifact_hash}")
-        fail(f"  error: {exc}")
+        fail(f"  error: could not load bundle: {exc}")
         return False
 
-    ok(f"sigstore verify: {path.name} ({sha256(path)})")
-
+    # Extract SAN from certificate and compare against expected identity
     try:
         from typing import cast
 
@@ -182,13 +181,36 @@ def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
         san_ext = cert.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
         san_val = cast(SubjectAlternativeName, san_ext.value)
         sans = san_val.get_values_for_type(UniformResourceIdentifier)
-        if sans:
-            info(f"  signed by: {sans[0]}")
-        info(f"  issuer: {cert.issuer.rfc4514_string()}")
-        info(f"  trust root: {OIDC_ISSUER}")
-    except (ImportError, ValueError, KeyError):
-        info(f"  trust root: {OIDC_ISSUER}")
+        if not sans:
+            fail(f"sigstore verify: {path.name}")
+            fail("  error: no SAN URI in signing certificate")
+            return False
+        actual_identity = sans[0]
+        if actual_identity != expected_identity:
+            fail(f"sigstore verify: {path.name}")
+            fail(f"  identity mismatch: {actual_identity}")
+            fail(f"  expected: {expected_identity}")
+            return False
+    except (ImportError, ValueError, KeyError) as exc:
+        fail(f"sigstore verify: {path.name}")
+        fail(f"  error: could not extract SAN from certificate: {exc}")
+        return False
 
+    # Cryptographic verification with sigstore library
+    try:
+        verifier = Verifier.production()
+        identity = policy.Identity(identity=expected_identity, issuer=OIDC_ISSUER)
+        verifier.verify_artifact(path.read_bytes(), bundle, identity)
+    except (sigstore.errors.VerificationError, ValueError, OSError) as exc:
+        artifact_hash = sha256(path)
+        fail(f"sigstore verify: {path.name}")
+        fail(f"  artifact: {artifact_hash}")
+        fail(f"  error: {exc}")
+        return False
+
+    ok(f"sigstore verify: {path.name} ({sha256(path)})")
+    info(f"  signed by: {actual_identity}")
+    info(f"  trust root: {OIDC_ISSUER}")
     return True
 
 

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -32,10 +32,20 @@ import sys
 import tomllib
 import urllib.parse
 from pathlib import Path
+from typing import cast
 
+import sigstore.errors
+from cryptography.x509 import (
+    ExtensionNotFound,
+    SubjectAlternativeName,
+    UniformResourceIdentifier,
+)
+from cryptography.x509.oid import ExtensionOID
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from sigstore.models import Bundle
+from sigstore.verify import Verifier, policy
 
 console = Console()
 
@@ -49,10 +59,17 @@ KNOWN_HOSTS = {
 
 # -- Trust anchors (derived from pyproject.toml) ---------------------------
 
-_pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
-PACKAGE_NAME = _pyproject["project"]["name"]
-_repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
-_repo_host = _repo_url.hostname
+try:
+    _pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    PACKAGE_NAME = _pyproject["project"]["name"]
+    _repo_url = urllib.parse.urlparse(_pyproject["project"]["urls"]["Repository"])
+    _repo_host = _repo_url.hostname
+except (FileNotFoundError, tomllib.TOMLDecodeError, KeyError) as exc:
+    console.print(f"[bold red]Cannot derive trust anchors from pyproject.toml: {exc}[/]")
+    console.print(
+        "[dim]Ensure pyproject.toml exists with [project].name and [project.urls].Repository[/]"
+    )
+    sys.exit(1)
 if _repo_host not in KNOWN_HOSTS:
     console.print(f"[bold red]Unknown repository host: {_repo_host}[/]")
     console.print(f"[dim]Known hosts: {', '.join(KNOWN_HOSTS)}[/]")
@@ -157,10 +174,6 @@ def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
         info(f"No sigstore bundle for {path.name}")
         return True
 
-    import sigstore.errors
-    from sigstore.models import Bundle
-    from sigstore.verify import Verifier, policy
-
     expected_identity = IDENTITY_TEMPLATE.format(version=version)
 
     try:
@@ -172,11 +185,6 @@ def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
 
     # Extract SAN from certificate and compare against expected identity
     try:
-        from typing import cast
-
-        from cryptography.x509 import SubjectAlternativeName, UniformResourceIdentifier
-        from cryptography.x509.oid import ExtensionOID
-
         cert = bundle.signing_certificate
         san_ext = cert.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
         san_val = cast(SubjectAlternativeName, san_ext.value)
@@ -191,7 +199,7 @@ def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
             fail(f"  identity mismatch: {actual_identity}")
             fail(f"  expected: {expected_identity}")
             return False
-    except (ImportError, ValueError, KeyError) as exc:
+    except (ValueError, KeyError, ExtensionNotFound) as exc:
         fail(f"sigstore verify: {path.name}")
         fail(f"  error: could not extract SAN from certificate: {exc}")
         return False
@@ -221,10 +229,6 @@ def verify_slsa_provenance(path: Path, provenance_path: Path, version: str) -> b
     if not provenance_path.exists():
         info("No SLSA provenance file found")
         return True
-
-    import sigstore.errors
-    from sigstore.models import Bundle
-    from sigstore.verify import Verifier, policy
 
     try:
         bundle = Bundle.from_json(provenance_path.read_bytes())
@@ -445,8 +449,6 @@ def main() -> int:
         break  # verify once
 
     # -- 4. GitHub attestations (sigstore Python) -----------------------
-    import sigstore.errors
-
     header("4. GitHub attestations (Python sigstore library)")
     for name, path in artifacts.items():
         att_file = gh_proofs / f"{name}.gh-attestation.json"
@@ -459,9 +461,6 @@ def main() -> int:
                 info(f"Empty GH attestation for {name}")
                 continue
             bundle_json = json.dumps(data[0]["attestation"]["bundle"]).encode()
-
-            from sigstore.models import Bundle
-            from sigstore.verify import Verifier, policy
 
             bundle = Bundle.from_json(bundle_json)
             verifier = Verifier.production()


### PR DESCRIPTION
## Summary

Addresses all 6 hardening items from Copilot's second review on PR #70.

1. **Publisher mismatch fails closed** — `verify_provenance.py` now returns
   `False` on repo/workflow mismatch instead of warning and continuing
2. **Cosign identity regexp tightened** — matches only `release.yml` workflow,
   not any workflow under the repo
3. **Document required PEP 740 keys** — KeyError on malformed attestations is
   intentional; added comments documenting this
4. **Use `version` parameter** — `fetch_gh_attestations` now logs the version
5. **Trust anchor error handling** — wrapped pyproject.toml parsing in
   try/except with clear error messages across all 3 scripts
6. **Document `_restructure_pep740_to_cosign` keys** — docstring notes
   required keys and intentional KeyError behavior

Closes #71.

## Test plan

- [x] Pre-commit passes
- [x] 158 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Addresses six hardening and error-handling items from Copilot review #70 (issue #71). Changes focus on failing closed for identity mismatches, tightening identity checks for cosign certificates, and defensive parsing/error handling for trust-anchor derivation and PEP 740 attestations.

### Key Changes

1. Publisher identity validation now fails closed
   - scripts/verify_provenance.py: Publisher repository/workflow mismatches are treated as failures (log via fail(...) and return False) instead of warnings that allow verification to continue.

2. Tightened cosign certificate identity matching and pre-checks
   - scripts/verify_cosign.py, scripts/verify_pure.py, scripts/verify_provenance.py:
     - Introduced IDENTITY_TEMPLATE for consistent GitHub Actions OIDC identity construction (workflow + tag).
     - Added explicit extraction of certificate SAN URI from sigstore/cosign bundles (no more retry fallback to a repo-wide regexp).
     - Pre-validate certificate identity (SAN) against the expected workflow identity and return False on mismatch before invoking cosign.
     - Switched cosign invocations from using a broad --certificate-identity-regexp to --certificate-identity where appropriate.

3. Defensive error handling for trust-anchor derivation
   - scripts/download_release.py, scripts/verify_cosign.py, scripts/verify_provenance.py, scripts/verify_pure.py:
     - Wrapped pyproject.toml loading/parsing and required-key access in try/except that catches FileNotFoundError, tomllib.TOMLDecodeError, and KeyError.
     - Emit clear Rich-formatted error messages and exit with status 1 on failure (instead of uncaught exceptions).

4. Documented/validated required PEP 740 keys and intentional KeyError behavior
   - scripts/verify_cosign.py, scripts/download_release.py:
     - Expanded docstrings and inline comments to list required PEP 740 key paths used to build cosign-compatible bundles.
     - Treat KeyError from missing attestation fields as an intentional per-artifact failure (documented), enabling per-artifact reporting rather than a crash.

5. Use version parameter for logging in attestation fetch
   - scripts/download_release.py:
     - fetch_gh_attestations now logs progress using the provided version parameter (e.g., "Fetching GH attestations for v{version}...").

6. Miscellaneous hardening and refactors
   - Replaced shelling out to openssl with certificate parsing using the cryptography library in verification paths.
   - Centralized identity formatting and moved several imports to module level where appropriate.
   - Improved error logging and explicit fail paths for bundle load/parsing failures.

### Test & Quality
- Pre-commit: passing
- Tests: 158 tests passing
- CHANGELOG.md: Updated under [Unreleased] to reflect verification/download hardening and identity tightening.

### Files Modified (high-level)
- CHANGELOG.md — updated Unreleased Fixed entries
- scripts/download_release.py — trust-anchor try/except, version logging, doc/comments
- scripts/verify_cosign.py — identity templating, SAN extraction, identity checks, docstrings, signature verification changes (signature of verify_pypi_attestation updated to accept version)
- scripts/verify_provenance.py — fail-closed publisher checks, SAN extraction, identity templating, trust-anchor parsing hardening
- scripts/verify_pure.py — trust-anchor hardening, SAN extraction/validation, refactor imports and verification policy use

Resolves #71.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->