### PR TITLE
fix: resolve CodeQL alerts — mixed returns and URL substring (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
   to prevent `IndexError` crash in verify scripts (#50).
 - Fix CodeQL mixed-returns alert: `get_version()` now raises `ValueError`
   instead of calling `sys.exit()` (#63).
-- Fix CodeQL incomplete-URL-substring alert in test_site.py (#63).
 - Publisher mismatch in verify_provenance.py now fails closed instead
   of warning and continuing (#71).
 - Tighten cosign identity regexp to match only the release workflow,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
   `download_release.py`'s `fetch_pypi_provenance` (#48).
 - Guard `stderr.splitlines()[-1]` against empty/whitespace-only stderr
   to prevent `IndexError` crash in verify scripts (#50).
+- Fix CodeQL mixed-returns alert: `get_version()` now raises `ValueError`
+  instead of calling `sys.exit()` (#63).
+- Fix CodeQL incomplete-URL-substring alert in test_site.py (#63).
 - Publisher mismatch in verify_provenance.py now fails closed instead
   of warning and continuing (#71).
 - Tighten cosign identity regexp to match only the release workflow,

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -74,7 +74,8 @@ def get_version() -> str:
         if line.startswith("__version__"):
             return line.split('"')[1]
     print("Could not detect version. Pass it as an argument.")
-    sys.exit(1)
+    msg = "Could not detect version from __init__.py or CLI argument"
+    raise ValueError(msg)
 
 
 def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -269,7 +269,8 @@ def extract_pypi_proofs(version: str) -> None:
 def main() -> int:
     try:
         version = get_version()
-    except ValueError:
+    except ValueError as exc:
+        print(f"Error: {exc}")
         return 1
     tag = f"{TAG_PREFIX}{version}"
 

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -267,7 +267,10 @@ def extract_pypi_proofs(version: str) -> None:
 
 
 def main() -> int:
-    version = get_version()
+    try:
+        version = get_version()
+    except ValueError:
+        return 1
     tag = f"{TAG_PREFIX}{version}"
 
     DIST_DIR.mkdir(exist_ok=True)

--- a/scripts/gen_ebuild.py
+++ b/scripts/gen_ebuild.py
@@ -59,7 +59,8 @@ def _validate_version(version: str) -> None:
 def main() -> int:
     try:
         version = get_version()
-    except ValueError:
+    except ValueError as exc:
+        print(f"Error: {exc}")
         return 1
     _validate_version(version)
     gentoo_version = pep440_to_gentoo(version)

--- a/scripts/gen_ebuild.py
+++ b/scripts/gen_ebuild.py
@@ -57,7 +57,10 @@ def _validate_version(version: str) -> None:
 
 
 def main() -> int:
-    version = get_version()
+    try:
+        version = get_version()
+    except ValueError:
+        return 1
     _validate_version(version)
     gentoo_version = pep440_to_gentoo(version)
 

--- a/scripts/gen_ebuild.py
+++ b/scripts/gen_ebuild.py
@@ -45,7 +45,8 @@ def get_version() -> str:
         if line.startswith("__version__"):
             return line.split('"')[1]
     print("Could not detect version. Pass it as an argument.")
-    sys.exit(1)
+    msg = "Could not detect version from __init__.py or CLI argument"
+    raise ValueError(msg)
 
 
 def _validate_version(version: str) -> None:

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -99,7 +99,8 @@ def get_version() -> str:
         if line.startswith("__version__"):
             return line.split('"')[1]
     console.print("[red]Could not detect version. Pass it as an argument.[/]")
-    sys.exit(1)
+    msg = "Could not detect version from __init__.py or CLI argument"
+    raise ValueError(msg)
 
 
 def sha256(path: Path) -> str:

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -461,7 +461,8 @@ def verify_checksums(artifacts: dict[str, Path], sums_file: Path) -> bool:
 def main() -> int:
     try:
         version = get_version()
-    except ValueError:
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/]")
         return 1
     console.print(
         Panel(
@@ -562,7 +563,7 @@ def main() -> int:
     provenance = gh_proofs / f"geek42-v{version}-provenance.intoto.jsonl"
     if not provenance.exists():
         provenance = gh_proofs / "geek42-provenance.intoto.jsonl"
-    for _name, path in artifacts.items():
+    for _, path in artifacts.items():
         if not verify_slsa_attestation(path, provenance):
             failures += 1
         break  # provenance covers all subjects, verify once
@@ -577,7 +578,7 @@ def main() -> int:
             border_style="dim",
         )
     )
-    for _name, path in artifacts.items():
+    for _, path in artifacts.items():
         if not verify_gh_attestation(path, gh_proofs, version):
             failures += 1
 

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -459,7 +459,10 @@ def verify_checksums(artifacts: dict[str, Path], sums_file: Path) -> bool:
 
 
 def main() -> int:
-    version = get_version()
+    try:
+        version = get_version()
+    except ValueError:
+        return 1
     console.print(
         Panel(
             f"Verifying [bold]{PACKAGE_NAME} {version}[/] with cosign\n"

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -134,7 +134,8 @@ def get_version() -> str:
         if line.startswith("__version__"):
             return line.split('"')[1]
     console.print("[red]Could not detect version. Pass it as an argument.[/]")
-    sys.exit(1)
+    msg = "Could not detect version from __init__.py or CLI argument"
+    raise ValueError(msg)
 
 
 def sha256(path: Path) -> str:

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -652,7 +652,8 @@ def verify_pypi_attestation(
 def main() -> int:
     try:
         version = get_version()
-    except ValueError:
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/]")
         return 1
     console.print(Panel(f"Verifying supply-chain security for [bold]{PACKAGE_NAME} {version}[/]"))
 

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -650,7 +650,10 @@ def verify_pypi_attestation(
 
 
 def main() -> int:
-    version = get_version()
+    try:
+        version = get_version()
+    except ValueError:
+        return 1
     console.print(Panel(f"Verifying supply-chain security for [bold]{PACKAGE_NAME} {version}[/]"))
 
     failures = 0

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -388,7 +388,10 @@ def verify_pypi_attestation(path: Path, provenance: dict, index_name: str) -> bo
 
 
 def main() -> int:
-    version = get_version()
+    try:
+        version = get_version()
+    except ValueError:
+        return 1
     console.print(
         Panel(
             f"Verifying [bold]{PACKAGE_NAME} {version}[/] with Python libraries\n"

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -390,7 +390,8 @@ def verify_pypi_attestation(path: Path, provenance: dict, index_name: str) -> bo
 def main() -> int:
     try:
         version = get_version()
-    except ValueError:
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/]")
         return 1
     console.print(
         Panel(

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -100,7 +100,8 @@ def get_version() -> str:
         if line.startswith("__version__"):
             return line.split('"')[1]
     console.print("[red]Could not detect version. Pass it as an argument.[/]")
-    sys.exit(1)
+    msg = "Could not detect version from __init__.py or CLI argument"
+    raise ValueError(msg)
 
 
 def sha256(path: Path) -> str:

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -71,7 +71,7 @@ def test_build_site_creates_posts(site_config: SiteConfig) -> None:
     html = (site_config.output_dir / "posts" / "2025-11-30-flexiblas-migration.html").read_text()
     assert "FlexiBLAS Migration" in html
     assert "Sam James" in html
-    assert "https://schema.org" in html
+    assert "schema.org" in html
 
 
 def test_build_site_creates_markdown_exports(site_config: SiteConfig) -> None:

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -71,7 +71,7 @@ def test_build_site_creates_posts(site_config: SiteConfig) -> None:
     html = (site_config.output_dir / "posts" / "2025-11-30-flexiblas-migration.html").read_text()
     assert "FlexiBLAS Migration" in html
     assert "Sam James" in html
-    assert "schema.org" in html
+    assert "https://schema.org" in html
 
 
 def test_build_site_creates_markdown_exports(site_config: SiteConfig) -> None:


### PR DESCRIPTION
## Summary

Resolves the CodeQL `py/mixed-returns` alerts. The `py/empty-except` and
`py/multiple-definition` alerts were already fixed in #105. The
`py/incomplete-url-substring-sanitization` alert needs proper HTML parsing
and is tracked separately in #107.

- **py/mixed-returns** (5 scripts): `get_version()` now raises `ValueError`
  instead of calling `sys.exit()`, so the function always explicitly returns
  `str` or raises — no implicit fall-through

Partially closes #63 (URL substring alert deferred to #107).

## Test plan

- [x] Pre-commit passes
- [x] 158 tests pass
- [x] All scripts smoke-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CodeQL Alerts Remediation: Mixed-Returns Fix

### Changes

The PR resolves `py/mixed-returns` CodeQL alerts by refactoring five script utilities to use exception-based error handling instead of process termination:

**scripts/download_release.py, scripts/gen_ebuild.py, scripts/verify_cosign.py, scripts/verify_provenance.py, scripts/verify_pure.py:**
- `get_version()` now raises `ValueError("Could not detect version from __init__.py or CLI argument")` when version detection fails, instead of calling `sys.exit(1)`
- Changes control flow from immediate process exit to exception propagation, enabling explicit handling upstream while maintaining non-zero exit status via the `sys.exit(main())` pattern in each script's main entrypoint
- Return type remains `str` in success paths

**CHANGELOG.md:**
- Documented the CodeQL mixed-returns fix under [Unreleased] → Fixed section with reference to #63

### Impact

- Eliminates mixed-return-type code paths (scripts previously returned `str` or implicitly exited the process)
- Enables better error handling for callers and test code
- Maintains backward compatibility in exit behavior for command-line invocations
- Follow-up commit separated incomplete-url-substring-sanitization fix into issue #107 for proper HTML-based resolution

### Testing

- 158 tests passing
- All scripts smoke-tested
- Pre-commit checks passing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->