### PR TITLE
docs: fix enforce_admins policy in release-setup.md (#68)

### DIFF
--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -40,7 +40,7 @@ now installed. `.github/settings.yml` declares:
   type check, audit, OSV scan, test, CodeQL, secret scan,
   dependency review
 - Signed commits required
-- Enforce for admins (no bypass)
+- Admins may bypass review requirement (`--admin`) but not CI checks
 - Linear history required
 - No force pushes, no branch deletion
 - Conversation resolution required

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -40,8 +40,9 @@ now installed. `.github/settings.yml` declares:
   type check, audit, OSV scan, test, CodeQL, secret scan,
   dependency review
 - Signed commits required
-- Admins may bypass review requirement (`--admin`) but not CI checks
-- Linear history required
+- Admins may bypass branch protection (`--admin`); project policy is
+  to only bypass review requirement, never CI checks
+- Merge commits (no linear history requirement)
 - No force pushes, no branch deletion
 - Conversation resolution required
 


### PR DESCRIPTION
## Summary

`docs/release-setup.md` incorrectly stated "Enforce for admins (no bypass)"
but `.github/settings.yml` has `enforce_admins: false`. Updated to match
actual policy: admins may bypass review requirement (`--admin`) but not CI checks.

Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)