### PR TITLE
fix: missing proofs now fail verification (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ### Fixed
 
+- Missing proofs (sigstore bundles, SLSA provenance, GH attestations,
+  PyPI attestations) now fail verification instead of silently passing (#52).
 - Replace hard-coded tool version badges with dynamic shields.io
   endpoints generated from `uv.lock` (#61).
 - Add uv as dev dependency so its version is tracked in `uv.lock`.

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -192,8 +192,8 @@ def info(msg: str) -> None:
 def verify_sigstore_blob(path: Path, bundle: Path, version: str) -> bool:
     """Verify a sigstore bundle against a file using cosign verify-blob."""
     if not bundle.exists():
-        info(f"No sigstore bundle for {path.name}")
-        return True  # not a failure, just not available
+        fail(f"No sigstore bundle for {path.name}")
+        return False
 
     # Extract and verify identity from bundle certificate before cosign check
     identity = IDENTITY_TEMPLATE.format(version=version)
@@ -231,8 +231,8 @@ def verify_sigstore_blob(path: Path, bundle: Path, version: str) -> bool:
 def verify_slsa_attestation(path: Path, provenance: Path) -> bool:
     """Verify SLSA L3 provenance using cosign verify-blob-attestation."""
     if not provenance.exists():
-        info("No SLSA provenance file found")
-        return True  # not a failure, just not available
+        fail("No SLSA provenance file found")
+        return False
 
     # SLSA provenance is signed by the slsa-framework generator, not our workflow
     result = run(
@@ -272,8 +272,8 @@ def verify_gh_attestation(path: Path, gh_proofs: Path, version: str) -> bool:
     if not bundle_file.exists():
         att_file = gh_proofs / f"{path.name}.gh-attestation.json"
         if not att_file.exists():
-            info(f"No GH attestation file for {path.name}")
-            return True
+            fail(f"No GH attestation file for {path.name}")
+            return False
         try:
             data = json.loads(att_file.read_text())
             if not isinstance(data, list) or not data:
@@ -611,7 +611,8 @@ def main() -> int:
         for name, path in artifacts.items():
             prov_file = proofs_dir / f"{name}.provenance.json"
             if not prov_file.exists():
-                info(f"{index_name}: no attestation for {name}")
+                fail(f"{index_name}: no attestation for {name}")
+                failures += 1
                 continue
             try:
                 prov = json.loads(prov_file.read_text(encoding="utf-8"))

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -277,8 +277,8 @@ def verify_gh_attestation(path: Path, gh_proofs: Path, version: str) -> bool:
         try:
             data = json.loads(att_file.read_text())
             if not isinstance(data, list) or not data:
-                info(f"Empty or invalid GH attestation for {path.name}")
-                return True
+                fail(f"No GH attestation entries for {path.name}")
+                return False
             bundle_json = json.dumps(data[0]["attestation"]["bundle"])
             bundle_file.write_text(bundle_json)
         except (json.JSONDecodeError, KeyError) as exc:

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -271,8 +271,8 @@ def _extract_san_from_bundle(bundle_path: Path) -> str | None:
 
 def verify_sigstore(path: Path, bundle: Path | None, version: str) -> bool:
     if not bundle or not bundle.exists():
-        info(f"sigstore: no bundle for {path.name}")
-        return True
+        fail(f"sigstore: no bundle for {path.name}")
+        return False
 
     expected_identity = IDENTITY_TEMPLATE.format(version=version)
     san = _extract_san_from_bundle(bundle)
@@ -724,7 +724,8 @@ def main() -> int:
                 failures += 1
             break  # show details once
     else:
-        info("No SLSA provenance file found in GitHub Release")
+        fail("No SLSA provenance file found in GitHub Release")
+        failures += 1
 
     # -- 5. PyPI / TestPyPI attestations (PEP 740) ---------------------
     header("5. PyPI / TestPyPI attestations (PEP 740)")
@@ -752,7 +753,8 @@ def main() -> int:
         for name, path in artifacts.items():
             prov_file = proofs_dir / f"{name}.provenance.json"
             if not prov_file.exists():
-                info(f"{index_name}: no attestation for {name}")
+                fail(f"{index_name}: no attestation for {name}")
+                failures += 1
                 continue
             try:
                 prov = json.loads(prov_file.read_text(encoding="utf-8"))

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -202,8 +202,8 @@ def verify_checksums(artifacts: dict[str, Path], sums_file: Path) -> bool:
 
 def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
     if not bundle_path.exists():
-        info(f"No sigstore bundle for {path.name}")
-        return True
+        fail(f"No sigstore bundle for {path.name}")
+        return False
 
     expected_identity = IDENTITY_TEMPLATE.format(version=version)
 
@@ -241,8 +241,8 @@ def verify_sigstore_bundle(path: Path, bundle_path: Path, version: str) -> bool:
 
 def verify_slsa_provenance(path: Path, provenance_path: Path, version: str) -> bool:
     if not provenance_path.exists():
-        info("No SLSA provenance file found")
-        return True
+        fail("No SLSA provenance file found")
+        return False
 
     try:
         bundle = Bundle.from_json(provenance_path.read_bytes())
@@ -471,7 +471,8 @@ def main() -> int:
     for name, path in artifacts.items():
         att_file = gh_proofs / f"{name}.gh-attestation.json"
         if not att_file.exists():
-            info(f"No GH attestation file for {name}")
+            fail(f"No GH attestation file for {name}")
+            failures += 1
             continue
         try:
             data = json.loads(att_file.read_text())
@@ -537,7 +538,8 @@ def main() -> int:
         for name, path in artifacts.items():
             prov_file = proofs_dir / f"{name}.provenance.json"
             if not prov_file.exists():
-                info(f"{index_name}: no attestation for {name}")
+                fail(f"{index_name}: no attestation for {name}")
+                failures += 1
                 continue
             try:
                 prov = json.loads(prov_file.read_text(encoding="utf-8"))

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -477,7 +477,8 @@ def main() -> int:
         try:
             data = json.loads(att_file.read_text())
             if not isinstance(data, list) or not data:
-                info(f"Empty GH attestation for {name}")
+                fail(f"No GH attestation entries for {name}")
+                failures += 1
                 continue
             bundle_json = json.dumps(data[0]["attestation"]["bundle"]).encode()
             expected_id = IDENTITY_TEMPLATE.format(version=version)


### PR DESCRIPTION
## Summary

Verification scripts should only succeed when they actually verify something.
Previously, missing proofs (sigstore bundles, SLSA provenance, GH attestations,
PyPI attestations) were silently treated as success — `info()` + `return True`.

Fixed all 11 locations across 3 scripts to use `fail()` + `return False` or
`failures += 1`.

Closes #52.

## Locations fixed

**Functions returning False on missing proof (was True):**
1. `verify_provenance.py` — `verify_sigstore()` missing bundle
2. `verify_pure.py` — `verify_sigstore_bundle()` missing bundle
3. `verify_pure.py` — `verify_slsa_provenance()` missing provenance
4. `verify_cosign.py` — `verify_sigstore_blob()` missing bundle
5. `verify_cosign.py` — `verify_slsa_attestation()` missing provenance
6. `verify_cosign.py` — `verify_gh_attestation()` missing attestation

**Callers now counting failures (was info + continue):**
7. `verify_provenance.py` — missing PyPI attestation per-file
8. `verify_provenance.py` — no SLSA provenance file
9. `verify_pure.py` — missing GH attestation file
10. `verify_pure.py` — missing PyPI attestation per-file
11. `verify_cosign.py` — missing PyPI attestation per-file

## Test plan

- [x] Pre-commit passes
- [x] 158 tests pass
- [x] All scripts smoke-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
This PR fixes verification scripts to properly fail when required supply-chain proofs are missing (sigstore bundles, SLSA provenance, GitHub attestations, and PyPI attestations), rather than silently treating missing evidence as successful verification. The fix changes behavior across 11 locations in three verification scripts.

## Changes

### verify_cosign.py
- `verify_sigstore_blob()`: Missing sigstore bundle now calls `fail()` and returns `False` instead of `info()` + `True`
- `verify_slsa_attestation()`: Missing provenance now calls `fail()` and returns `False` instead of `info()` + `True`
- `verify_gh_attestation()`: Missing `.gh-attestation.json` now calls `fail()` and returns `False` instead of `info()` + `True`
- PyPI/TestPyPI verification: Missing per-artifact provenance files (`<name>.provenance.json`) now increment the global `failures` counter and log `fail()` instead of only logging `info()`
- **Lines changed**: +8/-7

### verify_provenance.py
- `verify_sigstore()`: Missing sigstore bundle now logs failure and returns `False` instead of returning `True`
- `main()`: Missing SLSA L3 provenance files from GitHub Release now count as failures (increment `failures` counter) instead of being logged informationally
- PyPI/TestPyPI verification loop: Missing per-artifact provenance/attestation files now count as failures instead of being skipped without affecting the failure count
- **Lines changed**: +6/-4

### verify_pure.py
- `verify_sigstore_bundle()`: Missing `*.sigstore.json` now logs failure and returns `False` instead of returning `True`
- `verify_slsa_provenance()`: Missing provenance file now logs failure and returns `False` instead of returning `True`
- Missing GitHub attestation files (`*.gh-attestation.json`) now increment the `failures` counter
- Missing PyPI/TestPyPI provenance files (`*.provenance.json`) now increment the `failures` counter
- **Lines changed**: +8/-6

### CHANGELOG.md
- Added entry under **[Unreleased] → Fixed** documenting the change in behavior for missing proofs
- **Lines changed**: +2/-0

## Testing
- All 158 existing tests pass
- Pre-commit checks pass
- All scripts smoke-tested

## Impact
The changes ensure that verification runs will properly fail when critical supply-chain artifacts are absent, rather than incorrectly returning success. This closes issue #52 and prevents release verification from succeeding when required proofs cannot be found.

## Review Notes
Changes are confined to internal control flow and return values in verification paths; no exported/public API signatures were modified. Implementation follows the project's conventions for error handling and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->