### PR TITLE
fix: SLSA verification now checks all artifacts (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ### Fixed
 
+- SLSA verification now checks all artifacts, not just the first (#53).
 - Missing proofs (sigstore bundles, SLSA provenance, GH attestations,
   PyPI attestations) now fail verification instead of silently passing (#52).
 - Replace hard-coded tool version badges with dynamic shields.io

--- a/scripts/verify_cosign.py
+++ b/scripts/verify_cosign.py
@@ -566,7 +566,6 @@ def main() -> int:
     for _, path in artifacts.items():
         if not verify_slsa_attestation(path, provenance):
             failures += 1
-        break  # provenance covers all subjects, verify once
 
     # -- 4. GitHub attestations (cosign verify-blob-attestation) --------
     header("4. GitHub attestations (cosign verify-blob-attestation)")

--- a/scripts/verify_provenance.py
+++ b/scripts/verify_provenance.py
@@ -722,7 +722,6 @@ def main() -> int:
         for _name, path in artifacts.items():
             if not verify_slsa_provenance(path, provenance, version):
                 failures += 1
-            break  # show details once
     else:
         fail("No SLSA provenance file found in GitHub Release")
         failures += 1

--- a/scripts/verify_pure.py
+++ b/scripts/verify_pure.py
@@ -464,7 +464,6 @@ def main() -> int:
     for _name, path in artifacts.items():
         if not verify_slsa_provenance(path, provenance, version):
             failures += 1
-        break  # verify once
 
     # -- 4. GitHub attestations (sigstore Python) -----------------------
     header("4. GitHub attestations (Python sigstore library)")


### PR DESCRIPTION
## Summary

SLSA verification previously `break`ed after the first artifact, meaning only
the wheel was verified — the sdist was skipped entirely. Each artifact's sha256
should be individually checked against the provenance subjects.

Removed the `break` in all three verify scripts so all artifacts are verified.

Closes #53.

## Test plan

- [x] Pre-commit passes
- [x] 158 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)