### PR TITLE
feat: add version consistency pre-commit hook (#30)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: check-version
+        name: check version consistency (pyproject.toml vs __init__.py)
+        entry: uv run python scripts/check_version.py
+        language: system
+        files: ^(pyproject\.toml|src/geek42/__init__\.py)$
+        pass_filenames: false
+
       - id: regen-requirements
         name: regenerate requirements.txt and requirements-dev.txt
         entry: uv run python scripts/regen_requirements.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ### Added
 
+- Version consistency pre-commit hook that checks `pyproject.toml` and
+  `__init__.py` versions match (#30).
 - Companion workflow (`dependabot-regen.yml`) that auto-regenerates
   `requirements*.txt` after Dependabot updates dependencies.
 - Badge generation script (`scripts/regen_badges.py`) that extracts

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -17,30 +17,39 @@ INIT_PY = REPO_ROOT / "src" / "geek42" / "__init__.py"
 
 
 def get_pyproject_version() -> str:
-    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
-    return data["project"]["version"]
+    try:
+        data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+        return data["project"]["version"]
+    except (FileNotFoundError, tomllib.TOMLDecodeError, KeyError) as exc:
+        msg = f"could not read version from {PYPROJECT}: {exc}"
+        raise ValueError(msg) from exc
 
 
 def get_init_version() -> str | None:
     for line in INIT_PY.read_text(encoding="utf-8").splitlines():
-        match = re.match(r'^__version__\s*=\s*"(.+?)"', line)
+        match = re.match(r"""^__version__\s*=\s*['"](.+?)['"]""", line)
         if match:
             return match.group(1)
     return None
 
 
 def main() -> int:
-    pyproject_ver = get_pyproject_version()
+    try:
+        pyproject_ver = get_pyproject_version()
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
     init_ver = get_init_version()
 
     if init_ver is None:
-        print(f"ERROR: could not find __version__ in {INIT_PY}")
+        print(f"ERROR: could not find __version__ in {INIT_PY}", file=sys.stderr)
         return 1
 
     if pyproject_ver != init_ver:
-        print("ERROR: version mismatch")
-        print(f"  pyproject.toml: {pyproject_ver}")
-        print(f"  __init__.py:    {init_ver}")
+        print("ERROR: version mismatch", file=sys.stderr)
+        print(f"  pyproject.toml: {pyproject_ver}", file=sys.stderr)
+        print(f"  __init__.py:    {init_ver}", file=sys.stderr)
         return 1
 
     print(f"Version consistent: {pyproject_ver}")

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,0 +1,51 @@
+"""Check that pyproject.toml and __init__.py versions match.
+
+Usage:
+    uv run python scripts/check_version.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+INIT_PY = REPO_ROOT / "src" / "geek42" / "__init__.py"
+
+
+def get_pyproject_version() -> str:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    return data["project"]["version"]
+
+
+def get_init_version() -> str | None:
+    for line in INIT_PY.read_text(encoding="utf-8").splitlines():
+        match = re.match(r'^__version__\s*=\s*"(.+?)"', line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def main() -> int:
+    pyproject_ver = get_pyproject_version()
+    init_ver = get_init_version()
+
+    if init_ver is None:
+        print(f"ERROR: could not find __version__ in {INIT_PY}")
+        return 1
+
+    if pyproject_ver != init_ver:
+        print("ERROR: version mismatch")
+        print(f"  pyproject.toml: {pyproject_ver}")
+        print(f"  __init__.py:    {init_ver}")
+        return 1
+
+    print(f"Version consistent: {pyproject_ver}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add `scripts/check_version.py` that verifies `pyproject.toml` and
`src/geek42/__init__.py` versions match. Runs as a pre-commit hook
triggered when either file is staged.

This partially addresses #30 — packaging file consistency (Dockerfile,
debian, rpm, ebuild) is deferred to a packaging milestone.

## Test plan

- [x] Happy path: versions match → `Version consistent: 0.4.2a9`
- [x] Mismatch: edit `__init__.py` → clear error with both versions, exit 1
- [x] Pre-commit hook passes
- [x] 158 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Introduces two pre-commit/pre-push hooks to enforce version consistency and commit signature verification. Partially addresses issue #30 (version consistency); fully addresses issue #67 (signature enforcement).

## Changes

### New Scripts
- **`scripts/check_version.py`**: Validates version parity between `pyproject.toml` and `src/geek42/__init__.py`. Extracts `project.version` from TOML using `tomllib` and `__version__` from `__init__.py` via regex. Exits 1 on mismatch or missing `__version__`; exits 0 with success message on match.
- **`scripts/check_signatures.py`**: Enforces that all commits on the current branch are cryptographically signed before push. Queries `git log` for commits between upstream (or fallback to `origin/main`) and HEAD, accepting signatures marked as `G` (good), `U` (good untrusted), or `E` (expired, GitHub merge commits) and rejecting `N` (unsigned) and `B` (bad). Gracefully handles missing upstream/main refs by warning and returning 0.

### Pre-Commit Configuration (`.pre-commit-config.yaml`)
- **`check-version`** hook: Runs at `pre-commit` stage on changes to `pyproject.toml` or `src/geek42/__init__.py`; does not pass filenames.
- **`check-signatures`** hook: Runs at `pre-push` stage with `always_run: true`; does not pass filenames.

### Changelog
Updated `CHANGELOG.md` under `[Unreleased] → Added` with entries for:
- Pre-push signature verification (#67)
- Version consistency hook (#30)

## Code Quality
Both scripts follow project standards:
- Type hints throughout with PEP 604 union syntax (`str | None`)
- List-based subprocess calls with properly documented `noqa: S603` inline comments
- Informative error messaging with explicit version values on mismatch
- Pythonic path handling via `pathlib.Path`
- Modern stdlib (`tomllib` for TOML parsing)

## Scope
Version consistency check is scoped to `pyproject.toml` and `src/geek42/__init__.py` only; consistency with other packaging files (Dockerfile, debian/changelog, rpm spec, ebuild) deferred to packaging milestone milestone per PR description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->