### PR TITLE
fix: skip directories when iterating dist/ (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `download_release.py` crash when `dist/` contains subdirectories (#118).
+
 ## [0.4.2a10] - 2026-04-16
 
 ### Added

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -114,6 +114,8 @@ def download_github_release(version: str) -> bool:
 
     # Move non-distribution files to proofs/github/
     for f in sorted(DIST_DIR.iterdir()):
+        if f.is_dir():
+            continue
         if not is_dist_file(f.name):
             target = PROOFS_DIR / f.name
             if not target.exists():

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -114,7 +114,7 @@ def download_github_release(version: str) -> bool:
 
     # Move non-distribution files to proofs/github/
     for f in sorted(DIST_DIR.iterdir()):
-        if f.is_dir():
+        if not f.is_file():
             continue
         if not is_dist_file(f.name):
             target = PROOFS_DIR / f.name


### PR DESCRIPTION
## Summary

`download_release.py` crashes with `IsADirectoryError` when `dist/` contains
subdirectories (e.g. `dist/gentoo/` from `gen_ebuild.py`). Skip directories
when iterating.

Band-aid fix — proper redesign tracked in #117.

Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**Problem:** The `download_github_release()` function in `scripts/download_release.py` crashes with `IsADirectoryError` when the `dist/` directory contains subdirectories (e.g., `dist/gentoo/` created by `gen_ebuild.py`), because the script attempts to unlink all non-distribution entries without checking if they are files.

**Solution:** Added a directory check to skip directory entries when iterating over `DIST_DIR.iterdir()`. The logic now only processes files, preventing the exception when subdirectories are present.

**Changes:**
- `scripts/download_release.py`: Added `if f.is_dir(): continue` guard in the post-download relocation step (lines 117-118) within the `download_github_release()` function.

**Context:**
- This is a band-aid fix for issue #118; a full pipeline redesign is tracked separately in issue #117
- Previously, the script would attempt to call `f.unlink()` on directory objects, raising `IsADirectoryError`
- With this change, directories are skipped and only regular distribution/proof files are processed for moving to `proofs/github/`

**Code Quality Notes:**
- 2 lines added, 0 removed
- No changes to public/exported signatures
- The fix aligns with project conventions: all subprocess calls remain list-based, no bare exceptions
- **Note:** CHANGELOG.md was not updated under `[Unreleased]`, contrary to project requirement that "Every PR must update CHANGELOG.md"

**Implementation Details:**
The modified loop in `download_github_release()` now:
1. Iterates over sorted directory contents
2. Skips any directory entries early
3. Only checks non-distribution files for relocation to `proofs/github/`
4. Unlinks duplicates that already exist in the proofs directory

This prevents the script from attempting filesystem operations on directories, which was the root cause of the `IsADirectoryError`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->