### PR TITLE
feat: download_proofs.py, pyscv.net extraction, pyscv coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 - `download_proofs.py` — proof downloader with GitHub attestations, PyPI
   provenance, and cosign bundle extraction (#121).
 - `pyscv.net` — shared networking primitives (URL validation, redirect
-  resolution, atomic download, `gh` CLI runner).
+  resolution, atomic download).
 - `[tool.pyscv]` section in pyproject.toml for supply-chain verification
   trust anchors.
 - pyscv package included in coverage reports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 - `download_artifacts.py` — focused artifact downloader with `--source gh|pypi`,
   `--ext`, `--force`, `--dry-run`, `--verbose` options (#120).
+- `download_proofs.py` — proof downloader with GitHub attestations, PyPI
+  provenance, and cosign bundle extraction (#121).
+- `pyscv.net` — shared networking primitives (URL validation, redirect
+  resolution, atomic download, `gh` CLI runner).
 - `[tool.pyscv]` section in pyproject.toml for supply-chain verification
   trust anchors.
+- pyscv package included in coverage reports.
 - Research document analyzing multi-platform supply-chain verification
   support (GitLab, Bitbucket, Codeberg/Gitea, SourceHut, GCP Cloud Build).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ ignore = [
 [tool.pytest.ini_options]
 addopts = [
     "--cov=geek42",
+    "--cov=pyscv",
     "--cov-config=pyproject.toml",
     "--cov-report=term-missing",
     "--cov-report=html:.reports/test/htmlcov",
@@ -118,7 +119,7 @@ junit_logging = "all"
 junit_log_passing_tests = false
 
 [tool.coverage.run]
-source_pkgs = ["geek42"]
+source_pkgs = ["geek42", "pyscv"]
 branch = true
 relative_files = true
 

--- a/scripts/download_proofs.py
+++ b/scripts/download_proofs.py
@@ -1,0 +1,12 @@
+"""Download proof artifacts from GitHub, PyPI, and TestPyPI.
+
+Usage:
+    uv run python scripts/download_proofs.py 0.4.2a10
+    uv run python scripts/download_proofs.py 0.4.2a10 --source github
+    uv run python scripts/download_proofs.py 0.4.2a10 --dry-run
+"""
+
+from pyscv.download_proofs import app
+
+if __name__ == "__main__":
+    app()

--- a/src/pyscv/download_artifacts.py
+++ b/src/pyscv/download_artifacts.py
@@ -6,11 +6,9 @@ Does not touch proofs/ or perform any transformations.
 
 from __future__ import annotations
 
-import tempfile
 from enum import StrEnum
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Annotated
-from urllib.parse import urljoin, urlparse
 
 import httpx
 import typer
@@ -18,28 +16,17 @@ from pydantic import BaseModel
 from rich.console import Console
 
 from pyscv.config import PyscvConfig
+from pyscv.net import (
+    API_TIMEOUT,
+    GH_API_HEADERS,
+    atomic_download,
+    resolve_url,
+    safe_filename,
+)
 
 console = Console()
 
 DEFAULT_EXTENSIONS = (".whl", ".tar.gz")
-
-ALLOWED_HOSTS = frozenset(
-    {
-        "api.github.com",
-        "github.com",
-        "objects.githubusercontent.com",
-        "release-assets.githubusercontent.com",
-        "pypi.org",
-        "test.pypi.org",
-        "files.pythonhosted.org",
-        "test-files.pythonhosted.org",
-    }
-)
-
-GH_API_HEADERS = {
-    "Accept": "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-}
 
 
 # -- API response models ---------------------------------------------------
@@ -55,57 +42,12 @@ class PypiFileInfo(BaseModel):
     url: str
 
 
-# -- Download helpers ------------------------------------------------------
-
-
-def _validate_url(url: str) -> None:
-    """Validate that a URL uses HTTPS and an allowed host."""
-    parsed = urlparse(url)
-    if parsed.scheme != "https":
-        msg = f"Refusing non-HTTPS URL: {url}"
-        raise ValueError(msg)
-    if parsed.hostname not in ALLOWED_HOSTS:
-        msg = f"Refusing URL from unexpected host {parsed.hostname}: {url}"
-        raise ValueError(msg)
-
-
-def _safe_filename(name: str) -> str:
-    """Validate filename has no path traversal components."""
-    safe = PurePosixPath(name).name
-    if safe != name or ".." in name or "/" in name or "\\" in name:
-        msg = f"Refusing unsafe filename: {name!r}"
-        raise ValueError(msg)
-    return safe
-
-
-MAX_REDIRECTS = 5
-API_TIMEOUT = 30
-DOWNLOAD_TIMEOUT = 60
-
-
-def _resolve_url(url: str, timeout: float = API_TIMEOUT) -> str:
-    """Validate URL, follow redirect chain (each hop validated), return final URL."""
-    _validate_url(url)
-    start_url = url
-    for _ in range(MAX_REDIRECTS):
-        resp = httpx.head(url, follow_redirects=False, timeout=timeout)
-        if not resp.is_redirect:
-            return url
-        location = resp.headers.get("location")
-        if not location:
-            msg = f"Redirect {resp.status_code} from {url} missing Location header"
-            raise ValueError(msg)
-        # urljoin handles both absolute and relative Location headers:
-        # absolute → returned as-is, relative → resolved against current url
-        url = urljoin(url, location)
-        _validate_url(url)
-    msg = f"Too many redirects (>{MAX_REDIRECTS}) starting from {start_url}"
-    raise ValueError(msg)
+# -- Fetch helpers ---------------------------------------------------------
 
 
 def fetch_gh_release_assets(config: PyscvConfig, tag: str) -> list[GhReleaseAsset]:
     """Fetch asset list from GitHub Releases API."""
-    url = _resolve_url(f"https://api.github.com/repos/{config.repo_slug}/releases/tags/{tag}")
+    url = resolve_url(f"https://api.github.com/repos/{config.repo_slug}/releases/tags/{tag}")
     resp = httpx.get(url, timeout=API_TIMEOUT, follow_redirects=False, headers=GH_API_HEADERS)
     resp.raise_for_status()
     if resp.is_redirect:
@@ -117,7 +59,7 @@ def fetch_gh_release_assets(config: PyscvConfig, tag: str) -> list[GhReleaseAsse
 
 def fetch_pypi_release_files(config: PyscvConfig, version: str) -> list[PypiFileInfo]:
     """Fetch file list from PyPI JSON API."""
-    url = _resolve_url(f"{config.pypi_base_url}/pypi/{config.package_name}/{version}/json")
+    url = resolve_url(f"{config.pypi_base_url}/pypi/{config.package_name}/{version}/json")
     resp = httpx.get(url, timeout=API_TIMEOUT, follow_redirects=False)
     resp.raise_for_status()
     if resp.is_redirect:
@@ -125,28 +67,6 @@ def fetch_pypi_release_files(config: PyscvConfig, version: str) -> list[PypiFile
         raise ValueError(msg)
     raw_files = resp.json().get("urls", [])
     return [PypiFileInfo.model_validate(f) for f in raw_files]
-
-
-def atomic_download(url: str, dest: Path) -> None:
-    """Download a file atomically — write to temp dir then replace.
-
-    Validates URL and all redirect destinations before downloading.
-    """
-    final_url = _resolve_url(url)
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(dir=dest.parent) as tmpdir:
-        tmp_file = Path(tmpdir) / dest.name
-        with httpx.stream(
-            "GET", final_url, timeout=DOWNLOAD_TIMEOUT, follow_redirects=False
-        ) as stream:
-            stream.raise_for_status()
-            if stream.is_redirect:
-                msg = f"Unexpected redirect from {final_url}"
-                raise ValueError(msg)
-            with tmp_file.open("wb") as fh:
-                for chunk in stream.iter_bytes():
-                    fh.write(chunk)
-        tmp_file.replace(dest)
 
 
 # -- Source downloaders ----------------------------------------------------
@@ -178,7 +98,7 @@ def download_from_gh(
     skipped = 0
     for asset in assets:
         try:
-            name = _safe_filename(asset.name)
+            name = safe_filename(asset.name)
         except ValueError as exc:
             console.print(f"  [red]FAIL[/] {asset.name}: {exc}")
             return 1
@@ -247,7 +167,7 @@ def download_from_pypi(
     skipped = 0
     for file_info in files:
         try:
-            filename = _safe_filename(file_info.filename)
+            filename = safe_filename(file_info.filename)
         except ValueError as exc:
             console.print(f"  [red]FAIL[/] {file_info.filename}: {exc}")
             return 1

--- a/src/pyscv/download_artifacts.py
+++ b/src/pyscv/download_artifacts.py
@@ -18,8 +18,8 @@ from rich.console import Console
 from pyscv.config import PyscvConfig
 from pyscv.net import (
     API_TIMEOUT,
-    GH_API_HEADERS,
     atomic_download,
+    gh_api_headers,
     resolve_url,
     safe_filename,
 )
@@ -48,7 +48,7 @@ class PypiFileInfo(BaseModel):
 def fetch_gh_release_assets(config: PyscvConfig, tag: str) -> list[GhReleaseAsset]:
     """Fetch asset list from GitHub Releases API."""
     url = resolve_url(f"https://api.github.com/repos/{config.repo_slug}/releases/tags/{tag}")
-    resp = httpx.get(url, timeout=API_TIMEOUT, follow_redirects=False, headers=GH_API_HEADERS)
+    resp = httpx.get(url, timeout=API_TIMEOUT, follow_redirects=False, headers=gh_api_headers())
     resp.raise_for_status()
     if resp.is_redirect:
         msg = f"Unexpected redirect from {url}"

--- a/src/pyscv/download_proofs.py
+++ b/src/pyscv/download_proofs.py
@@ -227,8 +227,8 @@ def fetch_gh_attestations(
             bundle = attestations[0]["bundle"]
             bundle_json = json.dumps(bundle)
         except (KeyError, IndexError, TypeError) as exc:
-            console.print(f"  [yellow]skip[/] {name} bundle extraction — {exc}")
-            continue
+            console.print(f"  [red]FAIL[/] {name} bundle extraction — {exc}")
+            return 1
 
         bundle_file.write_text(bundle_json)
         console.print(f"  [green]OK[/] {name} attestation bundle")
@@ -297,10 +297,10 @@ def download_pypi_proofs(
     """Download PyPI provenance and extract all proof formats.
 
     For each dist file:
-    1. Fetch provenance → {file}.provenance.json
-    2. Extract PEP 740 attestation → {file}.publish.attestation
-    3. Restructure into cosign bundle → {file}.cosign-bundle.json
-    4. Download artifact copy from PyPI for integrity checking
+    1. Download artifact copy from PyPI for integrity checking
+    2. Fetch provenance → {file}.provenance.json
+    3. Extract PEP 740 attestation → {file}.publish.attestation
+    4. Restructure into cosign bundle → {file}.cosign-bundle.json
     """
     pypi_dir = proofs_source_dir(config, version, source_name)
     if not dry_run:
@@ -363,8 +363,8 @@ def download_pypi_proofs(
             return 1
 
         if prov is None:
-            console.print(f"  [yellow]skip[/] {filename} — no provenance")
-            continue
+            console.print(f"  [red]FAIL[/] {filename} — no provenance available")
+            return 1
 
         prov_file.write_text(json.dumps(prov, indent=2))
         console.print(f"  [green]OK[/] {filename} provenance")
@@ -377,6 +377,11 @@ def download_pypi_proofs(
 
         # Process first bundle only — PyPI currently returns one bundle per artifact.
         # If this changes, we'll need indexed filenames.
+        if len(bundles) > 1:
+            console.print(
+                f"  [yellow]WARNING[/] {filename} — {len(bundles)} bundles found, "
+                "processing first only"
+            )
         bundle_data = bundles[0]
         attestations = bundle_data.get("attestations", [])
         if not attestations:

--- a/src/pyscv/download_proofs.py
+++ b/src/pyscv/download_proofs.py
@@ -1,0 +1,549 @@
+"""Download proof artifacts from GitHub, PyPI, and TestPyPI.
+
+Downloads proof files and artifact copies for integrity checking.
+Performs all transformations (attestation extraction, cosign bundle
+restructuring) so verify scripts can be pure read-only.
+
+Proof directory layout:
+    proofs/{version}/
+    ├── github/    — release proofs + attestation bundles + artifact copies
+    ├── pypi/      — provenance + extracted attestations + artifact copies
+    └── testpypi/  — same as pypi/
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import StrEnum
+from pathlib import Path
+from typing import Annotated
+
+import httpx
+import typer
+from rich.console import Console
+
+from pyscv.config import PyscvConfig
+from pyscv.download_artifacts import (
+    fetch_gh_release_assets,
+    fetch_pypi_release_files,
+)
+from pyscv.net import (
+    API_TIMEOUT,
+    GH_API_HEADERS,
+    atomic_download,
+    resolve_url,
+    safe_filename,
+    validate_url,
+)
+
+console = Console()
+
+DIST_EXTENSIONS = (".whl", ".tar.gz")
+
+
+# -- Helpers ---------------------------------------------------------------
+
+
+def proofs_source_dir(config: PyscvConfig, version: str, source: str) -> Path:
+    """Compute the target directory: proofs_dir / version / source."""
+    if config.proofs_dir is None:
+        msg = "proofs_dir is required — call validate_required() first"
+        raise ValueError(msg)
+    return config.proofs_dir / version / source
+
+
+def _is_dist_file(name: str) -> bool:
+    """Return True if filename is a distribution artifact."""
+    return any(name.endswith(ext) for ext in DIST_EXTENSIONS)
+
+
+# -- Source 1: GitHub Release proofs ---------------------------------------
+
+
+def download_gh_release_proofs(
+    config: PyscvConfig,
+    version: str,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> int:
+    """Download proof assets and artifact copies from GitHub Release.
+
+    Uses the GitHub Releases API to fetch asset metadata, then downloads
+    each file via httpx with URL validation.
+    """
+    gh_dir = proofs_source_dir(config, version, "github")
+    tag = config.tag(version)
+
+    try:
+        assets = fetch_gh_release_assets(config, tag)
+    except (httpx.HTTPError, ValueError) as exc:
+        console.print(f"[red]ERROR: failed to fetch GitHub Release {tag}: {exc}[/]")
+        return 1
+
+    if not dry_run:
+        gh_dir.mkdir(parents=True, exist_ok=True)
+
+    downloaded = 0
+    skipped = 0
+    for asset in assets:
+        try:
+            name = safe_filename(asset.name)
+        except ValueError as exc:
+            console.print(f"  [red]FAIL[/] {asset.name}: {exc}")
+            return 1
+
+        dest = gh_dir / name
+
+        if dry_run:
+            if dest.exists() and not force:
+                console.print(f"  [yellow]exists[/] {name}")
+                skipped += 1
+            else:
+                console.print(f"  [green]download[/] {name}")
+                downloaded += 1
+            continue
+
+        if dest.exists() and not force:
+            if verbose:
+                console.print(f"  [dim]skip {name} (exists)[/]")
+            skipped += 1
+            continue
+
+        if verbose:
+            console.print(f"  [dim]downloading {name}...[/]")
+        try:
+            atomic_download(asset.browser_download_url, dest)
+        except (httpx.HTTPError, ValueError, OSError) as exc:
+            console.print(f"  [red]FAIL[/] {name}: {exc}")
+            return 1
+        console.print(f"  [green]OK[/] {name}")
+        downloaded += 1
+
+    action = "would be downloaded" if dry_run else "downloaded"
+    summary = f"{downloaded} {action}"
+    if skipped:
+        summary += f", {skipped} skipped"
+    console.print(f"  [bold]{summary}[/] from {tag}")
+    return 0
+
+
+# -- Source 2: GitHub Attestation API --------------------------------------
+
+
+def _sha256_file(path: Path) -> str:
+    """Compute SHA256 hex digest of a file."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def fetch_gh_attestation(
+    config: PyscvConfig,
+    artifact_path: Path,
+) -> list[dict] | None:
+    """Fetch attestation bundles for an artifact from the GitHub Attestations API.
+
+    Returns the list of attestation objects, or None if not available (404).
+    """
+    digest = _sha256_file(artifact_path)
+    url = resolve_url(
+        f"https://api.github.com/repos/{config.repo_slug}/attestations/sha256:{digest}"
+    )
+    resp = httpx.get(url, timeout=API_TIMEOUT, follow_redirects=False, headers=GH_API_HEADERS)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    if resp.is_redirect:
+        msg = f"Unexpected redirect from {url}"
+        raise ValueError(msg)
+    data = resp.json()
+    return data.get("attestations", [])
+
+
+def fetch_gh_attestations(
+    config: PyscvConfig,
+    version: str,
+    dist_filenames: list[str],
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> int:
+    """Fetch GitHub attestation bundles for each dist file via REST API.
+
+    Takes a list of dist filenames — uses the artifact copies
+    in the github proofs directory to compute SHA256 digests.
+
+    For each dist file:
+    1. Compute SHA256 of artifact copy in proofs/github/
+    2. Query ``GET /repos/{slug}/attestations/sha256:{digest}``
+    3. Save raw JSON → {file}.gh-attestation.json
+    4. Extract inner sigstore bundle → {file}.gh-attestation-bundle.json
+    """
+    gh_dir = proofs_source_dir(config, version, "github")
+    if not dry_run:
+        gh_dir.mkdir(parents=True, exist_ok=True)
+
+    for name in dist_filenames:
+        artifact_path = gh_dir / name
+        att_file = gh_dir / f"{name}.gh-attestation.json"
+        bundle_file = gh_dir / f"{name}.gh-attestation-bundle.json"
+
+        if att_file.exists() and not force:
+            if verbose:
+                console.print(f"  [dim]skip {name} attestation (exists)[/]")
+            continue
+
+        if dry_run:
+            console.print(f"  [green]fetch attestation[/] {name}")
+            continue
+
+        if not artifact_path.exists():
+            console.print(f"  [red]FAIL[/] {name} — artifact not found in proofs dir")
+            return 1
+
+        if verbose:
+            console.print(f"  [dim]fetching attestation for {name}...[/]")
+
+        try:
+            attestations = fetch_gh_attestation(config, artifact_path)
+        except (httpx.HTTPError, ValueError) as exc:
+            console.print(f"  [red]FAIL[/] {name} — attestation error: {exc}")
+            return 1
+
+        if not attestations:
+            console.print(f"  [red]FAIL[/] {name} — no attestation available")
+            return 1
+
+        att_file.write_text(json.dumps(attestations, indent=2))
+        console.print(f"  [green]OK[/] {name} attestation")
+
+        # Extract inner sigstore bundle for cosign
+        try:
+            bundle = attestations[0]["bundle"]
+            bundle_json = json.dumps(bundle)
+        except (KeyError, IndexError, TypeError) as exc:
+            console.print(f"  [yellow]skip[/] {name} bundle extraction — {exc}")
+            continue
+
+        bundle_file.write_text(bundle_json)
+        console.print(f"  [green]OK[/] {name} attestation bundle")
+
+    return 0
+
+
+# -- Source 3: PyPI / TestPyPI Integrity API -------------------------------
+
+
+def fetch_pypi_provenance(
+    config: PyscvConfig,
+    version: str,
+    filename: str,
+    base_url: str,
+) -> dict | None:
+    """Fetch provenance from PyPI Integrity API.
+
+    Returns the parsed JSON dict, or None if the provenance is not available (404).
+    Raises on other HTTP errors.
+    """
+    url = f"{base_url}/integrity/{config.package_name}/{version}/{filename}/provenance"
+    validate_url(url)
+    resolved = resolve_url(url)
+    resp = httpx.get(resolved, timeout=API_TIMEOUT, follow_redirects=False)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    if resp.is_redirect:
+        msg = f"Unexpected redirect from {url}"
+        raise ValueError(msg)
+    return resp.json()
+
+
+def _extract_cosign_bundle(att: dict) -> dict:
+    """Restructure a PEP 740 attestation into a cosign-compatible bundle.
+
+    Keys are required by PEP 740 — KeyError indicates a malformed attestation.
+    """
+    vm = att["verification_material"]
+    return {
+        "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+        "verificationMaterial": {
+            "certificate": {"rawBytes": vm["certificate"]},
+            "tlogEntries": vm["transparency_entries"],
+            "timestampVerificationData": {},
+        },
+        "dsseEnvelope": {
+            "payload": att["envelope"]["statement"],
+            "payloadType": "application/vnd.in-toto+json",
+            "signatures": [{"sig": att["envelope"]["signature"]}],
+        },
+    }
+
+
+def download_pypi_proofs(
+    config: PyscvConfig,
+    version: str,
+    source_name: str,
+    base_url: str,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> int:
+    """Download PyPI provenance and extract all proof formats.
+
+    For each dist file:
+    1. Fetch provenance → {file}.provenance.json
+    2. Extract PEP 740 attestation → {file}.publish.attestation
+    3. Restructure into cosign bundle → {file}.cosign-bundle.json
+    4. Download artifact copy from PyPI for integrity checking
+    """
+    pypi_dir = proofs_source_dir(config, version, source_name)
+    if not dry_run:
+        pypi_dir.mkdir(parents=True, exist_ok=True)
+
+    # Get file list from PyPI to download artifact copies
+    try:
+        files = fetch_pypi_release_files(config, version)
+    except (httpx.HTTPError, ValueError) as exc:
+        console.print(f"[red]ERROR: failed to fetch file list from {source_name}: {exc}[/]")
+        return 1
+
+    for file_info in files:
+        try:
+            filename = safe_filename(file_info.filename)
+        except ValueError as exc:
+            console.print(f"  [red]FAIL[/] {file_info.filename}: {exc}")
+            return 1
+
+        if not _is_dist_file(filename):
+            continue
+
+        # Download artifact copy for integrity checking
+        artifact_dest = pypi_dir / filename
+        if not artifact_dest.exists() or force:
+            if dry_run:
+                console.print(f"  [green]download[/] {filename}")
+            else:
+                if verbose:
+                    console.print(f"  [dim]downloading {filename}...[/]")
+                try:
+                    atomic_download(file_info.url, artifact_dest)
+                except (httpx.HTTPError, ValueError, OSError) as exc:
+                    console.print(f"  [red]FAIL[/] {filename}: {exc}")
+                    return 1
+                console.print(f"  [green]OK[/] {filename}")
+        elif verbose:
+            console.print(f"  [dim]skip {filename} (exists)[/]")
+
+        # Fetch provenance
+        prov_file = pypi_dir / f"{filename}.provenance.json"
+        if prov_file.exists() and not force:
+            if verbose:
+                console.print(f"  [dim]skip {filename} provenance (exists)[/]")
+            continue
+
+        if dry_run:
+            console.print(f"  [green]fetch provenance[/] {filename}")
+            continue
+
+        if verbose:
+            console.print(f"  [dim]fetching provenance for {filename}...[/]")
+        try:
+            prov = fetch_pypi_provenance(config, version, filename, base_url)
+        except (httpx.HTTPError, ValueError) as exc:
+            console.print(f"  [red]FAIL[/] {filename} provenance: {exc}")
+            return 1
+
+        if prov is None:
+            console.print(f"  [yellow]skip[/] {filename} — no provenance")
+            continue
+
+        prov_file.write_text(json.dumps(prov, indent=2))
+        console.print(f"  [green]OK[/] {filename} provenance")
+
+        # Extract attestations from provenance
+        bundles = prov.get("attestation_bundles", [])
+        if not bundles:
+            continue
+
+        for bundle_data in bundles:
+            attestations = bundle_data.get("attestations", [])
+            if not attestations:
+                continue
+            att = attestations[0]
+
+            # Extract individual PEP 740 attestation
+            att_file = pypi_dir / f"{filename}.publish.attestation"
+            att_file.write_text(json.dumps(att))
+            console.print(f"  [green]OK[/] {filename} .publish.attestation")
+
+            # Restructure into cosign-compatible bundle
+            try:
+                cosign_bundle = _extract_cosign_bundle(att)
+            except KeyError as exc:
+                console.print(f"  [yellow]skip[/] {filename} cosign bundle — missing key: {exc}")
+                continue
+
+            cosign_file = pypi_dir / f"{filename}.cosign-bundle.json"
+            cosign_file.write_text(json.dumps(cosign_bundle, indent=2))
+            console.print(f"  [green]OK[/] {filename} cosign bundle")
+
+    return 0
+
+
+# -- Orchestrator ----------------------------------------------------------
+
+
+class ProofSource(StrEnum):
+    github = "github"
+    pypi = "pypi"
+    testpypi = "testpypi"
+    all = "all"
+
+
+def download_proofs(
+    config: PyscvConfig,
+    version: str,
+    source: ProofSource,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> int:
+    """Download proofs from the specified source(s).
+
+    Returns 0 on success, 1 on any failure.
+    """
+    sources_to_fetch: list[ProofSource] = []
+    if source == ProofSource.all:
+        sources_to_fetch = [ProofSource.github, ProofSource.pypi, ProofSource.testpypi]
+    else:
+        sources_to_fetch = [source]
+
+    for src in sources_to_fetch:
+        if src == ProofSource.github:
+            console.print(f"\n[bold]GitHub Release proofs[/] for {config.tag(version)}")
+            code = download_gh_release_proofs(
+                config, version, force=force, dry_run=dry_run, verbose=verbose
+            )
+            if code != 0:
+                return code
+
+            # Collect dist filenames from the github proofs dir for attestation lookup
+            gh_dir = proofs_source_dir(config, version, "github")
+            dist_filenames = (
+                [f.name for f in sorted(gh_dir.iterdir()) if f.is_file() and _is_dist_file(f.name)]
+                if gh_dir.is_dir()
+                else []
+            )
+
+            console.print(f"\n[bold]GitHub attestations[/] for {config.tag(version)}")
+            code = fetch_gh_attestations(
+                config,
+                version,
+                dist_filenames,
+                force=force,
+                dry_run=dry_run,
+                verbose=verbose,
+            )
+            if code != 0:
+                return code
+
+        elif src == ProofSource.pypi:
+            console.print(f"\n[bold]PyPI proofs[/] for {config.package_name} {version}")
+            code = download_pypi_proofs(
+                config,
+                version,
+                "pypi",
+                "https://pypi.org",
+                force=force,
+                dry_run=dry_run,
+                verbose=verbose,
+            )
+            if code != 0:
+                return code
+
+        elif src == ProofSource.testpypi:
+            console.print(f"\n[bold]TestPyPI proofs[/] for {config.package_name} {version}")
+            code = download_pypi_proofs(
+                config,
+                version,
+                "testpypi",
+                "https://test.pypi.org",
+                force=force,
+                dry_run=dry_run,
+                verbose=verbose,
+            )
+            if code != 0:
+                return code
+
+        else:
+            msg = f"Unknown proof source: {src}"
+            raise ValueError(msg)
+
+    return 0
+
+
+# -- CLI -------------------------------------------------------------------
+
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def main(
+    version: Annotated[
+        str | None,
+        typer.Argument(help="Version to download proofs for. Default: from pyproject.toml."),
+    ] = None,
+    source: Annotated[
+        ProofSource,
+        typer.Option(help="Proof source (github, pypi, testpypi, all)."),
+    ] = ProofSource.all,
+    force: Annotated[
+        bool,
+        typer.Option("--force", "-f", help="Overwrite existing proof files."),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", "-n", help="Show what would be downloaded."),
+    ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Show detailed progress."),
+    ] = False,
+    pyproject: Annotated[
+        Path,
+        typer.Option(help="Path to pyproject.toml."),
+    ] = Path("pyproject.toml"),
+) -> None:
+    """Download proof artifacts from GitHub, PyPI, and TestPyPI."""
+    try:
+        config = PyscvConfig.from_pyproject(pyproject)
+    except ValueError as exc:
+        console.print(f"[red]ERROR: {exc}[/]")
+        raise typer.Exit(1) from exc
+
+    config = config.with_overrides(version=version)
+    try:
+        config.validate_required()
+    except ValueError as exc:
+        console.print(f"[red]ERROR: {exc}[/]")
+        raise typer.Exit(1) from exc
+
+    console.print(
+        f"[bold]Downloading proofs for {config.package_name} {config.version}[/]"
+        + (f" from [cyan]{source.value}[/]" if source != ProofSource.all else "")
+        + (" [yellow](dry run)[/]" if dry_run else "")
+    )
+
+    code = download_proofs(
+        config, config.version, source, force=force, dry_run=dry_run, verbose=verbose
+    )
+    raise typer.Exit(code)

--- a/src/pyscv/download_proofs.py
+++ b/src/pyscv/download_proofs.py
@@ -30,8 +30,8 @@ from pyscv.download_artifacts import (
 )
 from pyscv.net import (
     API_TIMEOUT,
-    GH_API_HEADERS,
     atomic_download,
+    gh_api_headers,
     resolve_url,
     safe_filename,
 )
@@ -153,7 +153,7 @@ def fetch_gh_attestation(
     url = resolve_url(
         f"https://api.github.com/repos/{config.repo_slug}/attestations/sha256:{digest}"
     )
-    resp = httpx.get(url, timeout=API_TIMEOUT, follow_redirects=False, headers=GH_API_HEADERS)
+    resp = httpx.get(url, timeout=API_TIMEOUT, follow_redirects=False, headers=gh_api_headers())
     if resp.status_code == 404:
         return None
     resp.raise_for_status()
@@ -289,6 +289,7 @@ def download_pypi_proofs(
     source_name: str,
     base_url: str,
     *,
+    use_testpypi: bool = False,
     force: bool = False,
     dry_run: bool = False,
     verbose: bool = False,
@@ -305,9 +306,8 @@ def download_pypi_proofs(
     if not dry_run:
         pypi_dir.mkdir(parents=True, exist_ok=True)
 
-    # Get file list from the same index we're fetching proofs from.
-    # Override config's pypi_base_url to match the explicit base_url.
-    pypi_config = config.model_copy(update={"use_testpypi": base_url == "https://test.pypi.org"})
+    # Fetch file list from the same index we're fetching proofs from
+    pypi_config = config.model_copy(update={"use_testpypi": use_testpypi})
     try:
         files = fetch_pypi_release_files(pypi_config, version)
     except (httpx.HTTPError, ValueError) as exc:
@@ -466,6 +466,7 @@ def download_proofs(
                 version,
                 "pypi",
                 "https://pypi.org",
+                use_testpypi=False,
                 force=force,
                 dry_run=dry_run,
                 verbose=verbose,
@@ -480,6 +481,7 @@ def download_proofs(
                 version,
                 "testpypi",
                 "https://test.pypi.org",
+                use_testpypi=True,
                 force=force,
                 dry_run=dry_run,
                 verbose=verbose,

--- a/src/pyscv/download_proofs.py
+++ b/src/pyscv/download_proofs.py
@@ -34,7 +34,6 @@ from pyscv.net import (
     atomic_download,
     resolve_url,
     safe_filename,
-    validate_url,
 )
 
 console = Console()
@@ -194,7 +193,7 @@ def fetch_gh_attestations(
         att_file = gh_dir / f"{name}.gh-attestation.json"
         bundle_file = gh_dir / f"{name}.gh-attestation-bundle.json"
 
-        if att_file.exists() and not force:
+        if att_file.exists() and bundle_file.exists() and not force:
             if verbose:
                 console.print(f"  [dim]skip {name} attestation (exists)[/]")
             continue
@@ -252,8 +251,7 @@ def fetch_pypi_provenance(
     Raises on other HTTP errors.
     """
     url = f"{base_url}/integrity/{config.package_name}/{version}/{filename}/provenance"
-    validate_url(url)
-    resolved = resolve_url(url)
+    resolved = resolve_url(url)  # resolve_url validates internally
     resp = httpx.get(resolved, timeout=API_TIMEOUT, follow_redirects=False)
     if resp.status_code == 404:
         return None
@@ -307,9 +305,11 @@ def download_pypi_proofs(
     if not dry_run:
         pypi_dir.mkdir(parents=True, exist_ok=True)
 
-    # Get file list from PyPI to download artifact copies
+    # Get file list from the same index we're fetching proofs from.
+    # Override config's pypi_base_url to match the explicit base_url.
+    pypi_config = config.model_copy(update={"use_testpypi": base_url == "https://test.pypi.org"})
     try:
-        files = fetch_pypi_release_files(config, version)
+        files = fetch_pypi_release_files(pypi_config, version)
     except (httpx.HTTPError, ValueError) as exc:
         console.print(f"[red]ERROR: failed to fetch file list from {source_name}: {exc}[/]")
         return 1
@@ -341,9 +341,11 @@ def download_pypi_proofs(
         elif verbose:
             console.print(f"  [dim]skip {filename} (exists)[/]")
 
-        # Fetch provenance
+        # Fetch provenance and extract derived files
         prov_file = pypi_dir / f"{filename}.provenance.json"
-        if prov_file.exists() and not force:
+        att_file = pypi_dir / f"{filename}.publish.attestation"
+        cosign_file = pypi_dir / f"{filename}.cosign-bundle.json"
+        if prov_file.exists() and att_file.exists() and cosign_file.exists() and not force:
             if verbose:
                 console.print(f"  [dim]skip {filename} provenance (exists)[/]")
             continue
@@ -370,29 +372,31 @@ def download_pypi_proofs(
         # Extract attestations from provenance
         bundles = prov.get("attestation_bundles", [])
         if not bundles:
-            continue
+            console.print(f"  [red]FAIL[/] {filename} — no attestation bundles in provenance")
+            return 1
 
-        for bundle_data in bundles:
-            attestations = bundle_data.get("attestations", [])
-            if not attestations:
-                continue
-            att = attestations[0]
+        # Process first bundle only — PyPI currently returns one bundle per artifact.
+        # If this changes, we'll need indexed filenames.
+        bundle_data = bundles[0]
+        attestations = bundle_data.get("attestations", [])
+        if not attestations:
+            console.print(f"  [red]FAIL[/] {filename} — empty attestations in bundle")
+            return 1
+        att = attestations[0]
 
-            # Extract individual PEP 740 attestation
-            att_file = pypi_dir / f"{filename}.publish.attestation"
-            att_file.write_text(json.dumps(att))
-            console.print(f"  [green]OK[/] {filename} .publish.attestation")
+        # Extract individual PEP 740 attestation
+        att_file.write_text(json.dumps(att))
+        console.print(f"  [green]OK[/] {filename} .publish.attestation")
 
-            # Restructure into cosign-compatible bundle
-            try:
-                cosign_bundle = _extract_cosign_bundle(att)
-            except KeyError as exc:
-                console.print(f"  [yellow]skip[/] {filename} cosign bundle — missing key: {exc}")
-                continue
+        # Restructure into cosign-compatible bundle
+        try:
+            cosign_bundle = _extract_cosign_bundle(att)
+        except KeyError as exc:
+            console.print(f"  [red]FAIL[/] {filename} cosign bundle — missing key: {exc}")
+            return 1
 
-            cosign_file = pypi_dir / f"{filename}.cosign-bundle.json"
-            cosign_file.write_text(json.dumps(cosign_bundle, indent=2))
-            console.print(f"  [green]OK[/] {filename} cosign bundle")
+        cosign_file.write_text(json.dumps(cosign_bundle, indent=2))
+        console.print(f"  [green]OK[/] {filename} cosign bundle")
 
     return 0
 

--- a/src/pyscv/net.py
+++ b/src/pyscv/net.py
@@ -35,9 +35,6 @@ def gh_api_headers() -> dict[str, str]:
     return headers
 
 
-# Keep module-level constant for backward compatibility
-GH_API_HEADERS = gh_api_headers()
-
 API_TIMEOUT = 30
 DOWNLOAD_TIMEOUT = 60
 MAX_REDIRECTS = 5

--- a/src/pyscv/net.py
+++ b/src/pyscv/net.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import shutil
-import subprocess
 import tempfile
 from pathlib import Path, PurePosixPath
 from urllib.parse import urljoin, urlparse
@@ -93,18 +91,3 @@ def atomic_download(url: str, dest: Path) -> None:
                 for chunk in stream.iter_bytes():
                     fh.write(chunk)
         tmp_file.replace(dest)
-
-
-def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
-    """Run a ``gh`` CLI command and return the CompletedProcess.
-
-    Locates ``gh`` via shutil.which, falls back to bare "gh".
-    Does not raise on non-zero exit — caller decides.
-    """
-    gh = shutil.which("gh") or "gh"
-    return subprocess.run(  # noqa: S603 — args are list, no shell
-        [gh, *args],
-        capture_output=True,
-        text=True,
-        check=False,
-    )

--- a/src/pyscv/net.py
+++ b/src/pyscv/net.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path, PurePosixPath
 from urllib.parse import urljoin, urlparse
@@ -21,10 +22,21 @@ ALLOWED_HOSTS = frozenset(
     }
 )
 
-GH_API_HEADERS = {
-    "Accept": "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-}
+
+def gh_api_headers() -> dict[str, str]:
+    """Build GitHub API headers, including auth token from environment if available."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+# Keep module-level constant for backward compatibility
+GH_API_HEADERS = gh_api_headers()
 
 API_TIMEOUT = 30
 DOWNLOAD_TIMEOUT = 60
@@ -55,10 +67,15 @@ def resolve_url(url: str, timeout: float = API_TIMEOUT) -> str:
     """Validate URL, follow redirect chain (each hop validated), return final URL."""
     validate_url(url)
     start_url = url
-    for _ in range(MAX_REDIRECTS):
+    redirects_followed = 0
+    while True:
         resp = httpx.head(url, follow_redirects=False, timeout=timeout)
         if not resp.is_redirect:
             return url
+        redirects_followed += 1
+        if redirects_followed > MAX_REDIRECTS:
+            msg = f"Too many redirects (>{MAX_REDIRECTS}) starting from {start_url}"
+            raise ValueError(msg)
         location = resp.headers.get("location")
         if not location:
             msg = f"Redirect {resp.status_code} from {url} missing Location header"
@@ -67,8 +84,6 @@ def resolve_url(url: str, timeout: float = API_TIMEOUT) -> str:
         # absolute → returned as-is, relative → resolved against current url
         url = urljoin(url, location)
         validate_url(url)
-    msg = f"Too many redirects (>{MAX_REDIRECTS}) starting from {start_url}"
-    raise ValueError(msg)
 
 
 def atomic_download(url: str, dest: Path) -> None:

--- a/src/pyscv/net.py
+++ b/src/pyscv/net.py
@@ -1,0 +1,110 @@
+"""Shared networking primitives for pyscv."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path, PurePosixPath
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+ALLOWED_HOSTS = frozenset(
+    {
+        "api.github.com",
+        "github.com",
+        "objects.githubusercontent.com",
+        "release-assets.githubusercontent.com",
+        "pypi.org",
+        "test.pypi.org",
+        "files.pythonhosted.org",
+        "test-files.pythonhosted.org",
+    }
+)
+
+GH_API_HEADERS = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+
+API_TIMEOUT = 30
+DOWNLOAD_TIMEOUT = 60
+MAX_REDIRECTS = 5
+
+
+def validate_url(url: str) -> None:
+    """Validate that a URL uses HTTPS and an allowed host."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        msg = f"Refusing non-HTTPS URL: {url}"
+        raise ValueError(msg)
+    if parsed.hostname not in ALLOWED_HOSTS:
+        msg = f"Refusing URL from unexpected host {parsed.hostname}: {url}"
+        raise ValueError(msg)
+
+
+def safe_filename(name: str) -> str:
+    """Validate filename has no path traversal components."""
+    safe = PurePosixPath(name).name
+    if safe != name or ".." in name or "/" in name or "\\" in name:
+        msg = f"Refusing unsafe filename: {name!r}"
+        raise ValueError(msg)
+    return safe
+
+
+def resolve_url(url: str, timeout: float = API_TIMEOUT) -> str:
+    """Validate URL, follow redirect chain (each hop validated), return final URL."""
+    validate_url(url)
+    start_url = url
+    for _ in range(MAX_REDIRECTS):
+        resp = httpx.head(url, follow_redirects=False, timeout=timeout)
+        if not resp.is_redirect:
+            return url
+        location = resp.headers.get("location")
+        if not location:
+            msg = f"Redirect {resp.status_code} from {url} missing Location header"
+            raise ValueError(msg)
+        # urljoin handles both absolute and relative Location headers:
+        # absolute → returned as-is, relative → resolved against current url
+        url = urljoin(url, location)
+        validate_url(url)
+    msg = f"Too many redirects (>{MAX_REDIRECTS}) starting from {start_url}"
+    raise ValueError(msg)
+
+
+def atomic_download(url: str, dest: Path) -> None:
+    """Download a file atomically — write to temp dir then replace.
+
+    Validates URL and all redirect destinations before downloading.
+    """
+    final_url = resolve_url(url)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=dest.parent) as tmpdir:
+        tmp_file = Path(tmpdir) / dest.name
+        with httpx.stream(
+            "GET", final_url, timeout=DOWNLOAD_TIMEOUT, follow_redirects=False
+        ) as stream:
+            stream.raise_for_status()
+            if stream.is_redirect:
+                msg = f"Unexpected redirect from {final_url}"
+                raise ValueError(msg)
+            with tmp_file.open("wb") as fh:
+                for chunk in stream.iter_bytes():
+                    fh.write(chunk)
+        tmp_file.replace(dest)
+
+
+def run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a ``gh`` CLI command and return the CompletedProcess.
+
+    Locates ``gh`` via shutil.which, falls back to bare "gh".
+    Does not raise on non-zero exit — caller decides.
+    """
+    gh = shutil.which("gh") or "gh"
+    return subprocess.run(  # noqa: S603 — args are list, no shell
+        [gh, *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )

--- a/tests/test_download_artifacts.py
+++ b/tests/test_download_artifacts.py
@@ -12,10 +12,7 @@ from pyscv.config import PyscvConfig
 from pyscv.download_artifacts import (
     GhReleaseAsset,
     PypiFileInfo,
-    _safe_filename,
-    _validate_url,
     app,
-    atomic_download,
     download_from_gh,
     download_from_pypi,
     fetch_gh_release_assets,
@@ -179,8 +176,8 @@ def _mock_response(json_data: dict) -> MagicMock:
 
 @pytest.fixture()
 def no_resolve(monkeypatch):
-    """Mock _resolve_url to return the URL unchanged (no HEAD requests)."""
-    monkeypatch.setattr("pyscv.download_artifacts._resolve_url", lambda url, **_kw: url)
+    """Mock resolve_url to return the URL unchanged (no HEAD requests)."""
+    monkeypatch.setattr("pyscv.download_artifacts.resolve_url", lambda url, **_kw: url)
 
 
 def test_fetch_gh_builds_correct_url(monkeypatch, config, no_resolve):
@@ -459,111 +456,8 @@ def test_pypi_raises_if_dist_dir_is_none():
         download_from_pypi(cfg, "1.0", (".whl",))
 
 
-# -- atomic_download -------------------------------------------------------
-
-
-@pytest.fixture()
-def no_redirects(monkeypatch):
-    """Mock _resolve_url to return the URL unchanged (no redirects)."""
-    monkeypatch.setattr("pyscv.download_artifacts._resolve_url", lambda url, **_kw: url)
-
-
-def _make_mock_stream(chunks: list[bytes]):
-    """Create a mock context manager for httpx.stream."""
-    stream = MagicMock()
-    stream.raise_for_status = MagicMock()
-    stream.is_redirect = False
-    stream.iter_bytes.return_value = chunks
-    stream.__enter__ = MagicMock(return_value=stream)
-    stream.__exit__ = MagicMock(return_value=False)
-    return stream
-
-
-def test_atomic_download_writes_complete_file(tmp_path, monkeypatch, no_redirects):
-    dest = tmp_path / "output.whl"
-    monkeypatch.setattr(
-        "pyscv.download_artifacts.httpx.stream",
-        lambda *_a, **_kw: _make_mock_stream([b"chunk1", b"chunk2"]),
-    )
-    atomic_download("https://github.com/f.whl", dest)
-    assert dest.read_bytes() == b"chunk1chunk2"
-
-
-def test_atomic_download_no_partial_on_status_error(tmp_path, monkeypatch, no_redirects):
-    dest = tmp_path / "output.whl"
-    stream = MagicMock()
-    stream.raise_for_status.side_effect = httpx.HTTPStatusError(
-        "500", request=MagicMock(), response=MagicMock(status_code=500)
-    )
-    stream.__enter__ = MagicMock(return_value=stream)
-    stream.__exit__ = MagicMock(return_value=False)
-    monkeypatch.setattr("pyscv.download_artifacts.httpx.stream", lambda *_a, **_kw: stream)
-    with pytest.raises(httpx.HTTPStatusError):
-        atomic_download("https://github.com/f.whl", dest)
-    assert not dest.exists()
-
-
-def test_atomic_download_no_partial_on_stream_error(tmp_path, monkeypatch, no_redirects):
-    """If iter_bytes fails mid-write, dest must not exist."""
-    dest = tmp_path / "output.whl"
-
-    def exploding_iter():
-        yield b"partial"
-        raise ConnectionError
-
-    stream = MagicMock()
-    stream.raise_for_status = MagicMock()
-    stream.is_redirect = False
-    stream.iter_bytes = exploding_iter
-    stream.__enter__ = MagicMock(return_value=stream)
-    stream.__exit__ = MagicMock(return_value=False)
-    monkeypatch.setattr("pyscv.download_artifacts.httpx.stream", lambda *_a, **_kw: stream)
-    with pytest.raises(ConnectionError):
-        atomic_download("https://github.com/f.whl", dest)
-    assert not dest.exists()
-
-
-def test_atomic_download_rejects_unexpected_redirect(tmp_path, monkeypatch, no_redirects):
-    dest = tmp_path / "output.whl"
-    stream = MagicMock()
-    stream.raise_for_status = MagicMock()
-    stream.is_redirect = True
-    stream.__enter__ = MagicMock(return_value=stream)
-    stream.__exit__ = MagicMock(return_value=False)
-    monkeypatch.setattr("pyscv.download_artifacts.httpx.stream", lambda *_a, **_kw: stream)
-    with pytest.raises(ValueError, match="Unexpected redirect"):
-        atomic_download("https://github.com/f.whl", dest)
-    assert not dest.exists()
-
-
-# -- URL validation --------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "https://github.com/file.whl",
-        "https://objects.githubusercontent.com/file.whl",
-        "https://pypi.org/file.whl",
-        "https://test.pypi.org/file.whl",
-        "https://files.pythonhosted.org/file.whl",
-    ],
-)
-def test_validate_url_allows_known_hosts(url):
-    _validate_url(url)  # should not raise
-
-
-@pytest.mark.parametrize(
-    ("url", "match"),
-    [
-        ("http://github.com/file.whl", "non-HTTPS"),
-        ("https://evil.com/file.whl", "unexpected host"),
-        ("ftp://pypi.org/file.whl", "non-HTTPS"),
-    ],
-)
-def test_validate_url_rejects_bad_urls(url, match):
-    with pytest.raises(ValueError, match=match):
-        _validate_url(url)
+# (URL validation, safe_filename, resolve_url, and atomic_download tests
+# are in tests/test_net.py — they test pyscv.net primitives directly.)
 
 
 # -- Config error handling -------------------------------------------------
@@ -624,82 +518,6 @@ def test_with_overrides_allows_falsy():
     cfg = PyscvConfig(package_name="pkg", version="1.0", repo_slug="o/r", use_testpypi=True)
     updated = cfg.with_overrides(use_testpypi=False)
     assert updated.use_testpypi is False  # False is not None, so it overrides
-
-
-def test_safe_filename_accepts_normal():
-    assert _safe_filename("pkg-1.0.whl") == "pkg-1.0.whl"
-
-
-@pytest.mark.parametrize("name", ["../evil.whl", "sub/dir.whl", "..\\evil.whl"])
-def test_safe_filename_rejects_traversal(name):
-    with pytest.raises(ValueError, match="unsafe filename"):
-        _safe_filename(name)
-
-
-# -- _resolve_url ----------------------------------------------------------
-
-
-def test_resolve_url_no_redirect(monkeypatch):
-    from pyscv.download_artifacts import _resolve_url
-
-    resp = MagicMock()
-    resp.is_redirect = False
-    monkeypatch.setattr("pyscv.download_artifacts.httpx.head", lambda *_a, **_kw: resp)
-    assert _resolve_url("https://github.com/file.whl") == "https://github.com/file.whl"
-
-
-def test_resolve_url_follows_valid_redirect(monkeypatch):
-    from pyscv.download_artifacts import _resolve_url
-
-    call_count = {"n": 0}
-
-    def fake_head(url, **kw):
-        call_count["n"] += 1
-        resp = MagicMock()
-        if call_count["n"] == 1:
-            resp.is_redirect = True
-            resp.headers = {"location": "https://release-assets.githubusercontent.com/file"}
-        else:
-            resp.is_redirect = False
-        return resp
-
-    monkeypatch.setattr("pyscv.download_artifacts.httpx.head", fake_head)
-    result = _resolve_url("https://github.com/file.whl")
-    assert result == "https://release-assets.githubusercontent.com/file"
-
-
-def test_resolve_url_rejects_bad_redirect(monkeypatch):
-    from pyscv.download_artifacts import _resolve_url
-
-    resp = MagicMock()
-    resp.is_redirect = True
-    resp.headers = {"location": "https://evil.com/steal"}
-    monkeypatch.setattr("pyscv.download_artifacts.httpx.head", lambda *_a, **_kw: resp)
-    with pytest.raises(ValueError, match="unexpected host"):
-        _resolve_url("https://github.com/file.whl")
-
-
-def test_resolve_url_too_many_redirects(monkeypatch):
-    from pyscv.download_artifacts import _resolve_url
-
-    resp = MagicMock()
-    resp.is_redirect = True
-    resp.headers = {"location": "https://github.com/next"}
-    monkeypatch.setattr("pyscv.download_artifacts.httpx.head", lambda *_a, **_kw: resp)
-    with pytest.raises(ValueError, match="Too many redirects"):
-        _resolve_url("https://github.com/start")
-
-
-def test_resolve_url_missing_location_header(monkeypatch):
-    from pyscv.download_artifacts import _resolve_url
-
-    resp = MagicMock()
-    resp.is_redirect = True
-    resp.status_code = 302
-    resp.headers = {}
-    monkeypatch.setattr("pyscv.download_artifacts.httpx.head", lambda *_a, **_kw: resp)
-    with pytest.raises(ValueError, match="missing Location header"):
-        _resolve_url("https://github.com/file.whl")
 
 
 def test_gh_returns_1_on_value_error(monkeypatch, config):

--- a/tests/test_download_proofs.py
+++ b/tests/test_download_proofs.py
@@ -359,8 +359,11 @@ def test_gh_attestations_dry_run(config):
 def test_gh_attestations_skip_existing(config, monkeypatch):
     filenames = _make_gh_dir_with_artifacts(config)
     gh_dir = config.proofs_dir / "1.0.0" / "github"
+    # Both att_file AND bundle_file must exist to skip
     (gh_dir / "testpkg-1.0.0.whl.gh-attestation.json").write_text("[]")
+    (gh_dir / "testpkg-1.0.0.whl.gh-attestation-bundle.json").write_text("{}")
     (gh_dir / "testpkg-1.0.0.tar.gz.gh-attestation.json").write_text("[]")
+    (gh_dir / "testpkg-1.0.0.tar.gz.gh-attestation-bundle.json").write_text("{}")
 
     call_count = {"n": 0}
 
@@ -378,7 +381,9 @@ def test_gh_attestations_skip_existing_verbose(config, monkeypatch):
     filenames = _make_gh_dir_with_artifacts(config)
     gh_dir = config.proofs_dir / "1.0.0" / "github"
     (gh_dir / "testpkg-1.0.0.whl.gh-attestation.json").write_text("[]")
+    (gh_dir / "testpkg-1.0.0.whl.gh-attestation-bundle.json").write_text("{}")
     (gh_dir / "testpkg-1.0.0.tar.gz.gh-attestation.json").write_text("[]")
+    (gh_dir / "testpkg-1.0.0.tar.gz.gh-attestation-bundle.json").write_text("{}")
     code = fetch_gh_attestations(config, "1.0.0", filenames, verbose=True)
     assert code == 0
 
@@ -542,13 +547,15 @@ def test_pypi_proofs_no_provenance(config, no_network_pypi, fake_download, monke
     assert code == 0
 
 
-def test_pypi_proofs_empty_bundles(config, no_network_pypi, fake_download, monkeypatch, no_resolve):
+def test_pypi_proofs_empty_bundles_fails(
+    config, no_network_pypi, fake_download, monkeypatch, no_resolve
+):
     monkeypatch.setattr(
         "pyscv.download_proofs.fetch_pypi_provenance",
         lambda *_a, **_kw: _make_provenance(with_bundles=False),
     )
     code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
-    assert code == 0
+    assert code == 1
 
 
 def test_pypi_proofs_dry_run(config, no_network_pypi, monkeypatch, no_resolve):
@@ -572,9 +579,11 @@ def test_pypi_proofs_skip_existing_provenance(
 ):
     pypi_dir = config.proofs_dir / "1.0.0" / "pypi"
     pypi_dir.mkdir(parents=True)
-    # Create existing provenance files so they get skipped
-    (pypi_dir / "testpkg-1.0.0.whl.provenance.json").write_text("{}")
-    (pypi_dir / "testpkg-1.0.0.tar.gz.provenance.json").write_text("{}")
+    # All three derived files must exist to skip
+    for name in ["testpkg-1.0.0.whl", "testpkg-1.0.0.tar.gz"]:
+        (pypi_dir / f"{name}.provenance.json").write_text("{}")
+        (pypi_dir / f"{name}.publish.attestation").write_text("{}")
+        (pypi_dir / f"{name}.cosign-bundle.json").write_text("{}")
     code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org", verbose=True)
     assert code == 0
 
@@ -613,8 +622,10 @@ def test_pypi_proofs_skip_existing_provenance_non_verbose(
 ):
     pypi_dir = config.proofs_dir / "1.0.0" / "pypi"
     pypi_dir.mkdir(parents=True)
-    (pypi_dir / "testpkg-1.0.0.whl.provenance.json").write_text("{}")
-    (pypi_dir / "testpkg-1.0.0.tar.gz.provenance.json").write_text("{}")
+    for name in ["testpkg-1.0.0.whl", "testpkg-1.0.0.tar.gz"]:
+        (pypi_dir / f"{name}.provenance.json").write_text("{}")
+        (pypi_dir / f"{name}.publish.attestation").write_text("{}")
+        (pypi_dir / f"{name}.cosign-bundle.json").write_text("{}")
     code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
     assert code == 0
 
@@ -640,7 +651,7 @@ def test_pypi_proofs_cosign_bundle_missing_key(
         lambda *_a, **_kw: bad_prov,
     )
     code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
-    assert code == 0  # graceful skip, not crash
+    assert code == 1  # malformed attestation is a hard failure
 
 
 def test_pypi_proofs_empty_attestations_list(
@@ -652,7 +663,7 @@ def test_pypi_proofs_empty_attestations_list(
         lambda *_a, **_kw: prov,
     )
     code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
-    assert code == 0
+    assert code == 1  # empty attestations is a hard failure
 
 
 def test_pypi_proofs_artifact_download_error(config, no_network_pypi, monkeypatch, no_resolve):

--- a/tests/test_download_proofs.py
+++ b/tests/test_download_proofs.py
@@ -1,0 +1,888 @@
+"""Tests for pyscv.download_proofs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from pyscv.config import PyscvConfig
+from pyscv.download_artifacts import GhReleaseAsset, PypiFileInfo
+from pyscv.download_proofs import (
+    ProofSource,
+    _extract_cosign_bundle,
+    _is_dist_file,
+    app,
+    download_gh_release_proofs,
+    download_proofs,
+    download_pypi_proofs,
+    fetch_gh_attestation,
+    fetch_gh_attestations,
+    fetch_pypi_provenance,
+    proofs_source_dir,
+)
+
+# -- Fixtures --------------------------------------------------------------
+
+
+@pytest.fixture()
+def config(tmp_path: Path) -> PyscvConfig:
+    return PyscvConfig(
+        package_name="testpkg",
+        version="1.0.0",
+        repo_slug="owner/repo",
+        tag_prefix="v",
+        dist_dir=tmp_path / "dist",
+        proofs_dir=tmp_path / "proofs",
+    )
+
+
+@pytest.fixture()
+def dist_files(config: PyscvConfig) -> list[Path]:
+    """Create fake dist files in dist_dir."""
+    if config.dist_dir is None:
+        msg = "dist_dir is required in test config"
+        raise ValueError(msg)
+    config.dist_dir.mkdir(parents=True, exist_ok=True)
+    files = []
+    for name in ["testpkg-1.0.0.whl", "testpkg-1.0.0.tar.gz"]:
+        f = config.dist_dir / name
+        f.write_bytes(b"fake-dist-content")
+        files.append(f)
+    return files
+
+
+@pytest.fixture()
+def gh_assets() -> list[GhReleaseAsset]:
+    return [
+        GhReleaseAsset(name="testpkg-1.0.0.whl", browser_download_url="https://github.com/whl"),
+        GhReleaseAsset(
+            name="testpkg-1.0.0.tar.gz", browser_download_url="https://github.com/sdist"
+        ),
+        GhReleaseAsset(name="SHA256SUMS.txt", browser_download_url="https://github.com/sums"),
+        GhReleaseAsset(
+            name="testpkg-1.0.0.whl.sigstore.json",
+            browser_download_url="https://github.com/sig",
+        ),
+    ]
+
+
+@pytest.fixture()
+def no_network_gh(monkeypatch, gh_assets):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_release_assets", lambda *_a, **_kw: gh_assets
+    )
+
+
+@pytest.fixture()
+def fake_download(monkeypatch):
+    """Replace atomic_download: records calls, creates empty dest files."""
+    calls: list[tuple[str, Path]] = []
+
+    def _download(url: str, dest: Path) -> None:
+        calls.append((url, dest))
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"fake")
+
+    monkeypatch.setattr("pyscv.download_proofs.atomic_download", _download)
+    return calls
+
+
+@pytest.fixture()
+def no_resolve(monkeypatch):
+    monkeypatch.setattr("pyscv.download_proofs.resolve_url", lambda url, **_kw: url)
+
+
+@pytest.fixture()
+def pypi_files() -> list[PypiFileInfo]:
+    return [
+        PypiFileInfo(filename="testpkg-1.0.0.whl", url="https://files.pythonhosted.org/whl"),
+        PypiFileInfo(filename="testpkg-1.0.0.tar.gz", url="https://files.pythonhosted.org/sdist"),
+    ]
+
+
+@pytest.fixture()
+def no_network_pypi(monkeypatch, pypi_files):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_release_files", lambda *_a, **_kw: pypi_files
+    )
+
+
+# -- proofs_source_dir -----------------------------------------------------
+
+
+def test_proofs_source_dir(config):
+    result = proofs_source_dir(config, "1.0.0", "github")
+    assert result == config.proofs_dir / "1.0.0" / "github"
+
+
+def test_proofs_source_dir_raises_if_proofs_dir_none():
+    cfg = PyscvConfig(package_name="pkg", version="1.0", repo_slug="o/r")
+    with pytest.raises(ValueError, match="proofs_dir is required"):
+        proofs_source_dir(cfg, "1.0", "github")
+
+
+# -- _is_dist_file ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("pkg.whl", True),
+        ("pkg.tar.gz", True),
+        ("SHA256SUMS.txt", False),
+        ("pkg.sigstore.json", False),
+    ],
+)
+def test_is_dist_file(name, expected):
+    assert _is_dist_file(name) is expected
+
+
+# -- download_gh_release_proofs --------------------------------------------
+
+
+def test_gh_release_proofs_dry_run(config, no_network_gh, fake_download):
+    code = download_gh_release_proofs(config, "1.0.0", dry_run=True)
+    assert code == 0
+    # No files created in dry run
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    assert not gh_dir.exists()
+
+
+def test_gh_release_proofs_downloads_all(config, no_network_gh, fake_download):
+    code = download_gh_release_proofs(config, "1.0.0")
+    assert code == 0
+    assert len(fake_download) == 4  # 2 dist + SHA256SUMS + sigstore
+
+
+def test_gh_release_proofs_skips_existing(config, no_network_gh, fake_download):
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    gh_dir.mkdir(parents=True)
+    (gh_dir / "SHA256SUMS.txt").write_bytes(b"old")
+    code = download_gh_release_proofs(config, "1.0.0")
+    assert code == 0
+    assert len(fake_download) == 3  # skipped SHA256SUMS.txt
+
+
+def test_gh_release_proofs_force_overwrites(config, no_network_gh, fake_download):
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    gh_dir.mkdir(parents=True)
+    (gh_dir / "SHA256SUMS.txt").write_bytes(b"old")
+    code = download_gh_release_proofs(config, "1.0.0", force=True)
+    assert code == 0
+    assert len(fake_download) == 4
+
+
+def test_gh_release_proofs_dry_run_shows_exists(config, no_network_gh, fake_download):
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    gh_dir.mkdir(parents=True)
+    (gh_dir / "SHA256SUMS.txt").write_bytes(b"old")
+    code = download_gh_release_proofs(config, "1.0.0", dry_run=True)
+    assert code == 0
+
+
+def test_gh_release_proofs_verbose(config, no_network_gh, fake_download):
+    # Existing file + verbose shows skip message
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    gh_dir.mkdir(parents=True)
+    (gh_dir / "SHA256SUMS.txt").write_bytes(b"old")
+    code = download_gh_release_proofs(config, "1.0.0", verbose=True)
+    assert code == 0
+
+
+def test_gh_release_proofs_fetch_error(config, monkeypatch):
+    def explode(*_a, **_kw):
+        raise httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=MagicMock(status_code=404)
+        )
+
+    monkeypatch.setattr("pyscv.download_proofs.fetch_gh_release_assets", explode)
+    assert download_gh_release_proofs(config, "1.0.0") == 1
+
+
+def test_gh_release_proofs_download_error(config, no_network_gh, monkeypatch):
+    def failing_download(_url, _dest):
+        raise httpx.HTTPStatusError(
+            "fail", request=MagicMock(), response=MagicMock(status_code=500)
+        )
+
+    monkeypatch.setattr("pyscv.download_proofs.atomic_download", failing_download)
+    assert download_gh_release_proofs(config, "1.0.0") == 1
+
+
+def test_gh_release_proofs_unsafe_filename(config, monkeypatch, fake_download):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_release_assets",
+        lambda *_a, **_kw: [
+            GhReleaseAsset(name="../evil.whl", browser_download_url="https://github.com/x"),
+        ],
+    )
+    assert download_gh_release_proofs(config, "1.0.0") == 1
+
+
+# -- fetch_gh_attestation (single artifact) --------------------------------
+
+
+def test_fetch_gh_attestation_returns_list(config, tmp_path, monkeypatch, no_resolve):
+    artifact = tmp_path / "fake.whl"
+    artifact.write_bytes(b"content")
+
+    attestations = [{"bundle": {"key": "val"}}]
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.is_redirect = False
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"attestations": attestations}
+    monkeypatch.setattr("pyscv.download_proofs.httpx.get", lambda *_a, **_kw: resp)
+
+    result = fetch_gh_attestation(config, artifact)
+    assert result == attestations
+
+
+def test_fetch_gh_attestation_returns_none_on_404(config, tmp_path, monkeypatch, no_resolve):
+    artifact = tmp_path / "fake.whl"
+    artifact.write_bytes(b"content")
+
+    resp = MagicMock()
+    resp.status_code = 404
+    monkeypatch.setattr("pyscv.download_proofs.httpx.get", lambda *_a, **_kw: resp)
+
+    result = fetch_gh_attestation(config, artifact)
+    assert result is None
+
+
+def test_fetch_gh_attestation_rejects_redirect(config, tmp_path, monkeypatch, no_resolve):
+    artifact = tmp_path / "fake.whl"
+    artifact.write_bytes(b"content")
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.is_redirect = True
+    resp.raise_for_status = MagicMock()
+    monkeypatch.setattr("pyscv.download_proofs.httpx.get", lambda *_a, **_kw: resp)
+
+    with pytest.raises(ValueError, match="Unexpected redirect"):
+        fetch_gh_attestation(config, artifact)
+
+
+def test_fetch_gh_attestation_raises_on_error(config, tmp_path, monkeypatch, no_resolve):
+    artifact = tmp_path / "fake.whl"
+    artifact.write_bytes(b"content")
+
+    resp = MagicMock()
+    resp.status_code = 500
+    resp.is_redirect = False
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "500", request=MagicMock(), response=MagicMock(status_code=500)
+    )
+    monkeypatch.setattr("pyscv.download_proofs.httpx.get", lambda *_a, **_kw: resp)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        fetch_gh_attestation(config, artifact)
+
+
+# -- fetch_gh_attestations (orchestrator) ----------------------------------
+
+
+def _make_gh_dir_with_artifacts(config):
+    """Create the github proofs dir with fake artifact copies."""
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    gh_dir.mkdir(parents=True)
+    (gh_dir / "testpkg-1.0.0.whl").write_bytes(b"fake")
+    (gh_dir / "testpkg-1.0.0.tar.gz").write_bytes(b"fake")
+    return ["testpkg-1.0.0.whl", "testpkg-1.0.0.tar.gz"]
+
+
+def test_gh_attestations_saves_and_extracts(config, monkeypatch):
+    filenames = _make_gh_dir_with_artifacts(config)
+    attestations = [{"bundle": {"key": "value"}}]
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_attestation", lambda *_a, **_kw: attestations
+    )
+    code = fetch_gh_attestations(config, "1.0.0", filenames)
+    assert code == 0
+
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    att_file = gh_dir / "testpkg-1.0.0.whl.gh-attestation.json"
+    bundle_file = gh_dir / "testpkg-1.0.0.whl.gh-attestation-bundle.json"
+    assert att_file.exists()
+    assert bundle_file.exists()
+    assert json.loads(bundle_file.read_text()) == {"key": "value"}
+
+
+def test_gh_attestations_api_error_fails(config, monkeypatch):
+    filenames = _make_gh_dir_with_artifacts(config)
+
+    def explode(*_a, **_kw):
+        raise httpx.HTTPStatusError("err", request=MagicMock(), response=MagicMock(status_code=500))
+
+    monkeypatch.setattr("pyscv.download_proofs.fetch_gh_attestation", explode)
+    code = fetch_gh_attestations(config, "1.0.0", filenames)
+    assert code == 1
+
+
+def test_gh_attestations_none_result_fails(config, monkeypatch):
+    filenames = _make_gh_dir_with_artifacts(config)
+    monkeypatch.setattr("pyscv.download_proofs.fetch_gh_attestation", lambda *_a, **_kw: None)
+    code = fetch_gh_attestations(config, "1.0.0", filenames)
+    assert code == 1
+
+
+def test_gh_attestations_empty_list_fails(config, monkeypatch):
+    filenames = _make_gh_dir_with_artifacts(config)
+    monkeypatch.setattr("pyscv.download_proofs.fetch_gh_attestation", lambda *_a, **_kw: [])
+    code = fetch_gh_attestations(config, "1.0.0", filenames)
+    assert code == 1
+
+
+def test_gh_attestations_missing_bundle_key(config, monkeypatch):
+    filenames = _make_gh_dir_with_artifacts(config)
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_attestation",
+        lambda *_a, **_kw: [{"no_bundle": True}],
+    )
+    code = fetch_gh_attestations(config, "1.0.0", filenames)
+    assert code == 0  # missing key: skip bundle extraction
+
+
+def test_gh_attestations_dry_run(config):
+    filenames = ["testpkg-1.0.0.whl", "testpkg-1.0.0.tar.gz"]
+    code = fetch_gh_attestations(config, "1.0.0", filenames, dry_run=True)
+    assert code == 0
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    assert not gh_dir.exists()
+
+
+def test_gh_attestations_skip_existing(config, monkeypatch):
+    filenames = _make_gh_dir_with_artifacts(config)
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    (gh_dir / "testpkg-1.0.0.whl.gh-attestation.json").write_text("[]")
+    (gh_dir / "testpkg-1.0.0.tar.gz.gh-attestation.json").write_text("[]")
+
+    call_count = {"n": 0}
+
+    def counting_fetch(*_a, **_kw):
+        call_count["n"] += 1
+        return [{"bundle": {}}]
+
+    monkeypatch.setattr("pyscv.download_proofs.fetch_gh_attestation", counting_fetch)
+    code = fetch_gh_attestations(config, "1.0.0", filenames)
+    assert code == 0
+    assert call_count["n"] == 0  # both skipped
+
+
+def test_gh_attestations_skip_existing_verbose(config, monkeypatch):
+    filenames = _make_gh_dir_with_artifacts(config)
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    (gh_dir / "testpkg-1.0.0.whl.gh-attestation.json").write_text("[]")
+    (gh_dir / "testpkg-1.0.0.tar.gz.gh-attestation.json").write_text("[]")
+    code = fetch_gh_attestations(config, "1.0.0", filenames, verbose=True)
+    assert code == 0
+
+
+def test_gh_attestations_artifact_not_downloaded_fails(config):
+    """When artifact copy doesn't exist in proofs dir, fail."""
+    filenames = ["testpkg-1.0.0.whl"]
+    gh_dir = config.proofs_dir / "1.0.0" / "github"
+    gh_dir.mkdir(parents=True)
+    code = fetch_gh_attestations(config, "1.0.0", filenames)
+    assert code == 1
+
+
+def test_gh_attestations_verbose(config, monkeypatch):
+    filenames = _make_gh_dir_with_artifacts(config)
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_attestation",
+        lambda *_a, **_kw: [{"bundle": {"key": "value"}}],
+    )
+    code = fetch_gh_attestations(config, "1.0.0", filenames, verbose=True)
+    assert code == 0
+
+
+def test_pypi_provenance_rejects_redirect(monkeypatch, config, no_resolve):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.is_redirect = True
+    resp.raise_for_status = MagicMock()
+    monkeypatch.setattr("pyscv.download_proofs.httpx.get", lambda *_a, **_kw: resp)
+    with pytest.raises(ValueError, match="Unexpected redirect"):
+        fetch_pypi_provenance(config, "1.0.0", "pkg.whl", "https://pypi.org")
+
+
+def test_pypi_proofs_skips_non_dist_files(config, monkeypatch, fake_download, no_resolve):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_release_files",
+        lambda *_a, **_kw: [
+            PypiFileInfo(filename="testpkg-1.0.0.whl", url="https://files.pythonhosted.org/whl"),
+            PypiFileInfo(filename="metadata.json", url="https://files.pythonhosted.org/meta"),
+        ],
+    )
+    monkeypatch.setattr("pyscv.download_proofs.fetch_pypi_provenance", lambda *_a, **_kw: None)
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
+    assert code == 0
+    # Only the whl should be downloaded, not metadata.json
+    assert len(fake_download) == 1
+
+
+def test_pypi_provenance_returns_dict(monkeypatch, config, no_resolve):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.is_redirect = False
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"attestation_bundles": []}
+    monkeypatch.setattr("pyscv.download_proofs.httpx.get", lambda *_a, **_kw: resp)
+
+    result = fetch_pypi_provenance(config, "1.0.0", "pkg.whl", "https://pypi.org")
+    assert result == {"attestation_bundles": []}
+
+
+def test_pypi_provenance_returns_none_on_404(monkeypatch, config, no_resolve):
+    resp = MagicMock()
+    resp.status_code = 404
+    monkeypatch.setattr("pyscv.download_proofs.httpx.get", lambda *_a, **_kw: resp)
+
+    result = fetch_pypi_provenance(config, "1.0.0", "pkg.whl", "https://pypi.org")
+    assert result is None
+
+
+def test_pypi_provenance_raises_on_other_error(monkeypatch, config, no_resolve):
+    resp = MagicMock()
+    resp.status_code = 500
+    resp.is_redirect = False
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "500", request=MagicMock(), response=MagicMock(status_code=500)
+    )
+    monkeypatch.setattr("pyscv.download_proofs.httpx.get", lambda *_a, **_kw: resp)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        fetch_pypi_provenance(config, "1.0.0", "pkg.whl", "https://pypi.org")
+
+
+# -- _extract_cosign_bundle ------------------------------------------------
+
+
+def test_extract_cosign_bundle_structure():
+    att = {
+        "verification_material": {
+            "certificate": "cert_bytes",
+            "transparency_entries": [{"entry": 1}],
+        },
+        "envelope": {
+            "statement": "payload_data",
+            "signature": "sig_data",
+        },
+    }
+    bundle = _extract_cosign_bundle(att)
+    assert bundle["mediaType"] == "application/vnd.dev.sigstore.bundle.v0.3+json"
+    assert bundle["verificationMaterial"]["certificate"]["rawBytes"] == "cert_bytes"
+    assert bundle["verificationMaterial"]["tlogEntries"] == [{"entry": 1}]
+    assert bundle["dsseEnvelope"]["payload"] == "payload_data"
+    assert bundle["dsseEnvelope"]["signatures"][0]["sig"] == "sig_data"
+
+
+def test_extract_cosign_bundle_missing_key():
+    with pytest.raises(KeyError):
+        _extract_cosign_bundle({"verification_material": {}})
+
+
+# -- download_pypi_proofs --------------------------------------------------
+
+
+def _make_provenance(*, with_bundles: bool = True) -> dict:
+    """Create a fake PyPI provenance response."""
+    if not with_bundles:
+        return {"attestation_bundles": []}
+    return {
+        "attestation_bundles": [
+            {
+                "attestations": [
+                    {
+                        "verification_material": {
+                            "certificate": "cert",
+                            "transparency_entries": [{"e": 1}],
+                        },
+                        "envelope": {
+                            "statement": "stmt",
+                            "signature": "sig",
+                        },
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def test_pypi_proofs_full_pipeline(config, no_network_pypi, fake_download, monkeypatch, no_resolve):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: _make_provenance(),
+    )
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
+    assert code == 0
+
+    pypi_dir = config.proofs_dir / "1.0.0" / "pypi"
+    # Artifact copies downloaded
+    assert len(fake_download) == 2
+
+    # Provenance files created
+    assert (pypi_dir / "testpkg-1.0.0.whl.provenance.json").exists()
+    assert (pypi_dir / "testpkg-1.0.0.whl.publish.attestation").exists()
+    assert (pypi_dir / "testpkg-1.0.0.whl.cosign-bundle.json").exists()
+
+
+def test_pypi_proofs_no_provenance(config, no_network_pypi, fake_download, monkeypatch, no_resolve):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: None,
+    )
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
+    assert code == 0
+
+
+def test_pypi_proofs_empty_bundles(config, no_network_pypi, fake_download, monkeypatch, no_resolve):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: _make_provenance(with_bundles=False),
+    )
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
+    assert code == 0
+
+
+def test_pypi_proofs_dry_run(config, no_network_pypi, monkeypatch, no_resolve):
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org", dry_run=True)
+    assert code == 0
+    pypi_dir = config.proofs_dir / "1.0.0" / "pypi"
+    assert not pypi_dir.exists()
+
+
+def test_pypi_proofs_verbose(config, no_network_pypi, fake_download, monkeypatch, no_resolve):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: _make_provenance(),
+    )
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org", verbose=True)
+    assert code == 0
+
+
+def test_pypi_proofs_skip_existing_provenance(
+    config, no_network_pypi, fake_download, monkeypatch, no_resolve
+):
+    pypi_dir = config.proofs_dir / "1.0.0" / "pypi"
+    pypi_dir.mkdir(parents=True)
+    # Create existing provenance files so they get skipped
+    (pypi_dir / "testpkg-1.0.0.whl.provenance.json").write_text("{}")
+    (pypi_dir / "testpkg-1.0.0.tar.gz.provenance.json").write_text("{}")
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org", verbose=True)
+    assert code == 0
+
+
+def test_pypi_proofs_skip_existing_artifact(
+    config, no_network_pypi, fake_download, monkeypatch, no_resolve
+):
+    pypi_dir = config.proofs_dir / "1.0.0" / "pypi"
+    pypi_dir.mkdir(parents=True)
+    (pypi_dir / "testpkg-1.0.0.whl").write_bytes(b"existing")
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: _make_provenance(),
+    )
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org", verbose=True)
+    assert code == 0
+
+
+def test_pypi_proofs_skip_existing_artifact_non_verbose(
+    config, no_network_pypi, fake_download, monkeypatch, no_resolve
+):
+    pypi_dir = config.proofs_dir / "1.0.0" / "pypi"
+    pypi_dir.mkdir(parents=True)
+    (pypi_dir / "testpkg-1.0.0.whl").write_bytes(b"existing")
+    (pypi_dir / "testpkg-1.0.0.tar.gz").write_bytes(b"existing")
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: _make_provenance(),
+    )
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
+    assert code == 0
+
+
+def test_pypi_proofs_skip_existing_provenance_non_verbose(
+    config, no_network_pypi, fake_download, monkeypatch, no_resolve
+):
+    pypi_dir = config.proofs_dir / "1.0.0" / "pypi"
+    pypi_dir.mkdir(parents=True)
+    (pypi_dir / "testpkg-1.0.0.whl.provenance.json").write_text("{}")
+    (pypi_dir / "testpkg-1.0.0.tar.gz.provenance.json").write_text("{}")
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
+    assert code == 0
+
+
+def test_pypi_proofs_cosign_bundle_missing_key(
+    config, no_network_pypi, fake_download, monkeypatch, no_resolve
+):
+    """Malformed attestation with missing verification_material keys."""
+    bad_prov = {
+        "attestation_bundles": [
+            {
+                "attestations": [
+                    {
+                        "verification_material": {},  # missing certificate, transparency_entries
+                        "envelope": {"statement": "s", "signature": "sig"},
+                    }
+                ]
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: bad_prov,
+    )
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
+    assert code == 0  # graceful skip, not crash
+
+
+def test_pypi_proofs_empty_attestations_list(
+    config, no_network_pypi, fake_download, monkeypatch, no_resolve
+):
+    prov = {"attestation_bundles": [{"attestations": []}]}
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: prov,
+    )
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
+    assert code == 0
+
+
+def test_pypi_proofs_artifact_download_error(config, no_network_pypi, monkeypatch, no_resolve):
+    def failing_download(_url, _dest):
+        raise httpx.HTTPStatusError(
+            "fail", request=MagicMock(), response=MagicMock(status_code=500)
+        )
+
+    monkeypatch.setattr("pyscv.download_proofs.atomic_download", failing_download)
+    assert download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org") == 1
+
+
+def test_pypi_proofs_unsafe_filename(config, monkeypatch, no_resolve):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_release_files",
+        lambda *_a, **_kw: [PypiFileInfo(filename="../evil.whl", url="https://pypi.org/x")],
+    )
+    assert download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org") == 1
+
+
+def test_pypi_proofs_fetch_error(config, monkeypatch):
+    def explode(*_a, **_kw):
+        raise httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=MagicMock(status_code=500)
+        )
+
+    monkeypatch.setattr("pyscv.download_proofs.fetch_pypi_release_files", explode)
+    assert download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org") == 1
+
+
+def test_pypi_proofs_provenance_fetch_error(
+    config, no_network_pypi, fake_download, monkeypatch, no_resolve
+):
+    def explode(*_a, **_kw):
+        raise httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=MagicMock(status_code=500)
+        )
+
+    monkeypatch.setattr("pyscv.download_proofs.fetch_pypi_provenance", explode)
+    assert download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org") == 1
+
+
+# -- download_proofs orchestrator ------------------------------------------
+
+
+def test_download_proofs_github_only(config, monkeypatch, no_network_gh, fake_download):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_attestation",
+        lambda *_a, **_kw: [{"bundle": {"key": "val"}}],
+    )
+    code = download_proofs(config, "1.0.0", ProofSource.github)
+    assert code == 0
+
+
+def test_download_proofs_pypi_only(config, monkeypatch, no_network_pypi, fake_download, no_resolve):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: None,
+    )
+    code = download_proofs(config, "1.0.0", ProofSource.pypi)
+    assert code == 0
+
+
+def test_download_proofs_testpypi_only(
+    config, monkeypatch, no_network_pypi, fake_download, no_resolve
+):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: None,
+    )
+    code = download_proofs(config, "1.0.0", ProofSource.testpypi)
+    assert code == 0
+
+
+def test_download_proofs_unknown_source(config):
+    with pytest.raises(ValueError, match="Unknown proof source"):
+        download_proofs(config, "1.0.0", "bogus")  # type: ignore[arg-type]  # noqa: PGH003  # ty: ignore[invalid-argument-type]
+
+
+def test_download_proofs_fails_on_attestation_error(
+    config, monkeypatch, no_network_gh, fake_download
+):
+    """If attestation step fails, orchestrator returns 1."""
+
+    def fail_attestations(*_a, **_kw):
+        return 1
+
+    monkeypatch.setattr("pyscv.download_proofs.fetch_gh_attestations", fail_attestations)
+    assert download_proofs(config, "1.0.0", ProofSource.github) == 1
+
+
+def test_download_proofs_fails_on_pypi_error(config, monkeypatch):
+    def explode(*_a, **_kw):
+        raise httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=MagicMock(status_code=500)
+        )
+
+    monkeypatch.setattr("pyscv.download_proofs.fetch_pypi_release_files", explode)
+    assert download_proofs(config, "1.0.0", ProofSource.pypi) == 1
+
+
+def test_download_proofs_fails_on_testpypi_error(config, monkeypatch):
+    def explode(*_a, **_kw):
+        raise httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=MagicMock(status_code=500)
+        )
+
+    monkeypatch.setattr("pyscv.download_proofs.fetch_pypi_release_files", explode)
+    assert download_proofs(config, "1.0.0", ProofSource.testpypi) == 1
+
+
+def test_download_proofs_fails_on_gh_error(config, monkeypatch):
+    def explode(*_a, **_kw):
+        raise httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=MagicMock(status_code=404)
+        )
+
+    monkeypatch.setattr("pyscv.download_proofs.fetch_gh_release_assets", explode)
+    assert download_proofs(config, "1.0.0", ProofSource.github) == 1
+
+
+def test_download_proofs_all_sources(
+    config, monkeypatch, no_network_gh, fake_download, no_network_pypi, no_resolve
+):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_attestation",
+        lambda *_a, **_kw: [{"bundle": {"key": "val"}}],
+    )
+    monkeypatch.setattr("pyscv.download_proofs.fetch_pypi_provenance", lambda *_a, **_kw: None)
+    code = download_proofs(config, "1.0.0", ProofSource.all)
+    assert code == 0
+
+
+# -- CLI -------------------------------------------------------------------
+
+
+@pytest.fixture()
+def cli_pyproject(tmp_path: Path) -> Path:
+    p = tmp_path / "pyproject.toml"
+    p.write_text("""\
+[project]
+name = "clipkg"
+version = "1.0.0"
+
+[tool.pyscv]
+repo-slug = "owner/clipkg"
+dist-dir = "dist"
+proofs-dir = "proofs"
+""")
+    return p
+
+
+@pytest.fixture()
+def cli_runner():
+    from typer.testing import CliRunner
+
+    return CliRunner()
+
+
+def test_cli_dry_run(cli_runner, cli_pyproject, monkeypatch):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_release_assets",
+        lambda *_a, **_kw: [],
+    )
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_attestation",
+        lambda *_a, **_kw: [{"bundle": {"key": "val"}}],
+    )
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_release_files",
+        lambda *_a, **_kw: [],
+    )
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: None,
+    )
+    result = cli_runner.invoke(app, ["1.0.0", "--dry-run", "--pyproject", str(cli_pyproject)])
+    assert result.exit_code == 0
+
+
+def test_cli_source_github(cli_runner, cli_pyproject, monkeypatch):
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_release_assets",
+        lambda *_a, **_kw: [],
+    )
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_attestation",
+        lambda *_a, **_kw: [{"bundle": {"key": "val"}}],
+    )
+    result = cli_runner.invoke(
+        app, ["1.0.0", "--source", "github", "--dry-run", "--pyproject", str(cli_pyproject)]
+    )
+    assert result.exit_code == 0
+
+
+def test_cli_missing_pyproject(cli_runner, tmp_path):
+    result = cli_runner.invoke(app, ["1.0.0", "--pyproject", str(tmp_path / "nope.toml")])
+    assert result.exit_code == 1
+    assert "cannot read" in result.output
+
+
+def test_cli_missing_version(cli_runner, tmp_path):
+    p = tmp_path / "pyproject.toml"
+    p.write_text("""\
+[project]
+name = "clipkg"
+
+[tool.pyscv]
+repo-slug = "owner/clipkg"
+dist-dir = "dist"
+proofs-dir = "proofs"
+""")
+    result = cli_runner.invoke(app, ["--pyproject", str(p)])
+    assert result.exit_code == 1
+    assert "missing required fields" in result.output
+
+
+def test_cli_default_version_from_pyproject(cli_runner, cli_pyproject, monkeypatch):
+    captured = {}
+
+    def fake_fetch(config, tag):
+        captured["tag"] = tag
+        return []
+
+    monkeypatch.setattr("pyscv.download_proofs.fetch_gh_release_assets", fake_fetch)
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_gh_attestation",
+        lambda *_a, **_kw: [{"bundle": {"key": "val"}}],
+    )
+    monkeypatch.setattr("pyscv.download_proofs.fetch_pypi_release_files", lambda *_a, **_kw: [])
+    result = cli_runner.invoke(app, ["--dry-run", "--pyproject", str(cli_pyproject)])
+    assert result.exit_code == 0
+    assert captured["tag"] == "v1.0.0"

--- a/tests/test_download_proofs.py
+++ b/tests/test_download_proofs.py
@@ -345,7 +345,7 @@ def test_gh_attestations_missing_bundle_key(config, monkeypatch):
         lambda *_a, **_kw: [{"no_bundle": True}],
     )
     code = fetch_gh_attestations(config, "1.0.0", filenames)
-    assert code == 0  # missing key: skip bundle extraction
+    assert code == 1  # missing bundle key is a hard failure
 
 
 def test_gh_attestations_dry_run(config):
@@ -425,7 +425,10 @@ def test_pypi_proofs_skips_non_dist_files(config, monkeypatch, fake_download, no
             PypiFileInfo(filename="metadata.json", url="https://files.pythonhosted.org/meta"),
         ],
     )
-    monkeypatch.setattr("pyscv.download_proofs.fetch_pypi_provenance", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: _make_provenance(),
+    )
     code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
     assert code == 0
     # Only the whl should be downloaded, not metadata.json
@@ -538,13 +541,33 @@ def test_pypi_proofs_full_pipeline(config, no_network_pypi, fake_download, monke
     assert (pypi_dir / "testpkg-1.0.0.whl.cosign-bundle.json").exists()
 
 
-def test_pypi_proofs_no_provenance(config, no_network_pypi, fake_download, monkeypatch, no_resolve):
+def test_pypi_proofs_warns_on_multiple_bundles(
+    config, no_network_pypi, fake_download, monkeypatch, no_resolve, capsys
+):
+    """Multiple bundles triggers a warning but still succeeds (first bundle used)."""
+    multi_bundle_prov = {
+        "attestation_bundles": [
+            _make_provenance()["attestation_bundles"][0],
+            _make_provenance()["attestation_bundles"][0],
+        ]
+    }
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: multi_bundle_prov,
+    )
+    code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
+    assert code == 0
+
+
+def test_pypi_proofs_no_provenance_fails(
+    config, no_network_pypi, fake_download, monkeypatch, no_resolve
+):
     monkeypatch.setattr(
         "pyscv.download_proofs.fetch_pypi_provenance",
         lambda *_a, **_kw: None,
     )
     code = download_pypi_proofs(config, "1.0.0", "pypi", "https://pypi.org")
-    assert code == 0
+    assert code == 1
 
 
 def test_pypi_proofs_empty_bundles_fails(
@@ -721,7 +744,7 @@ def test_download_proofs_github_only(config, monkeypatch, no_network_gh, fake_do
 def test_download_proofs_pypi_only(config, monkeypatch, no_network_pypi, fake_download, no_resolve):
     monkeypatch.setattr(
         "pyscv.download_proofs.fetch_pypi_provenance",
-        lambda *_a, **_kw: None,
+        lambda *_a, **_kw: _make_provenance(),
     )
     code = download_proofs(config, "1.0.0", ProofSource.pypi)
     assert code == 0
@@ -732,7 +755,7 @@ def test_download_proofs_testpypi_only(
 ):
     monkeypatch.setattr(
         "pyscv.download_proofs.fetch_pypi_provenance",
-        lambda *_a, **_kw: None,
+        lambda *_a, **_kw: _make_provenance(),
     )
     code = download_proofs(config, "1.0.0", ProofSource.testpypi)
     assert code == 0
@@ -792,7 +815,10 @@ def test_download_proofs_all_sources(
         "pyscv.download_proofs.fetch_gh_attestation",
         lambda *_a, **_kw: [{"bundle": {"key": "val"}}],
     )
-    monkeypatch.setattr("pyscv.download_proofs.fetch_pypi_provenance", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        "pyscv.download_proofs.fetch_pypi_provenance",
+        lambda *_a, **_kw: _make_provenance(),
+    )
     code = download_proofs(config, "1.0.0", ProofSource.all)
     assert code == 0
 

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -9,6 +9,7 @@ import pytest
 
 from pyscv.net import (
     atomic_download,
+    gh_api_headers,
     resolve_url,
     safe_filename,
     validate_url,
@@ -188,3 +189,28 @@ def test_atomic_download_rejects_unexpected_redirect(tmp_path, monkeypatch, no_r
     with pytest.raises(ValueError, match="Unexpected redirect"):
         atomic_download("https://github.com/f.whl", dest)
     assert not dest.exists()
+
+
+# -- gh_api_headers --------------------------------------------------------
+
+
+def test_gh_api_headers_without_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    headers = gh_api_headers()
+    assert "Authorization" not in headers
+    assert headers["Accept"] == "application/vnd.github+json"
+
+
+def test_gh_api_headers_with_github_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    headers = gh_api_headers()
+    assert headers["Authorization"] == "Bearer ghp_test123"
+
+
+def test_gh_api_headers_with_gh_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "ghp_fallback")
+    headers = gh_api_headers()
+    assert headers["Authorization"] == "Bearer ghp_fallback"

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -1,0 +1,234 @@
+"""Tests for pyscv.net — shared networking primitives."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from pyscv.net import (
+    atomic_download,
+    resolve_url,
+    run_gh,
+    safe_filename,
+    validate_url,
+)
+
+# -- validate_url ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/file.whl",
+        "https://objects.githubusercontent.com/file.whl",
+        "https://pypi.org/file.whl",
+        "https://test.pypi.org/file.whl",
+        "https://files.pythonhosted.org/file.whl",
+    ],
+)
+def test_validate_url_allows_known_hosts(url):
+    validate_url(url)  # should not raise
+
+
+@pytest.mark.parametrize(
+    ("url", "match"),
+    [
+        ("http://github.com/file.whl", "non-HTTPS"),
+        ("https://evil.com/file.whl", "unexpected host"),
+        ("ftp://pypi.org/file.whl", "non-HTTPS"),
+    ],
+)
+def test_validate_url_rejects_bad_urls(url, match):
+    with pytest.raises(ValueError, match=match):
+        validate_url(url)
+
+
+# -- safe_filename ---------------------------------------------------------
+
+
+def test_safe_filename_accepts_normal():
+    assert safe_filename("pkg-1.0.whl") == "pkg-1.0.whl"
+
+
+@pytest.mark.parametrize("name", ["../evil.whl", "sub/dir.whl", "..\\evil.whl"])
+def test_safe_filename_rejects_traversal(name):
+    with pytest.raises(ValueError, match="unsafe filename"):
+        safe_filename(name)
+
+
+# -- resolve_url -----------------------------------------------------------
+
+
+def test_resolve_url_no_redirect(monkeypatch):
+    resp = MagicMock()
+    resp.is_redirect = False
+    monkeypatch.setattr("pyscv.net.httpx.head", lambda *_a, **_kw: resp)
+    assert resolve_url("https://github.com/file.whl") == "https://github.com/file.whl"
+
+
+def test_resolve_url_follows_valid_redirect(monkeypatch):
+    call_count = {"n": 0}
+
+    def fake_head(url, **kw):
+        call_count["n"] += 1
+        resp = MagicMock()
+        if call_count["n"] == 1:
+            resp.is_redirect = True
+            resp.headers = {"location": "https://release-assets.githubusercontent.com/file"}
+        else:
+            resp.is_redirect = False
+        return resp
+
+    monkeypatch.setattr("pyscv.net.httpx.head", fake_head)
+    result = resolve_url("https://github.com/file.whl")
+    assert result == "https://release-assets.githubusercontent.com/file"
+
+
+def test_resolve_url_rejects_bad_redirect(monkeypatch):
+    resp = MagicMock()
+    resp.is_redirect = True
+    resp.headers = {"location": "https://evil.com/steal"}
+    monkeypatch.setattr("pyscv.net.httpx.head", lambda *_a, **_kw: resp)
+    with pytest.raises(ValueError, match="unexpected host"):
+        resolve_url("https://github.com/file.whl")
+
+
+def test_resolve_url_too_many_redirects(monkeypatch):
+    resp = MagicMock()
+    resp.is_redirect = True
+    resp.headers = {"location": "https://github.com/next"}
+    monkeypatch.setattr("pyscv.net.httpx.head", lambda *_a, **_kw: resp)
+    with pytest.raises(ValueError, match="Too many redirects"):
+        resolve_url("https://github.com/start")
+
+
+def test_resolve_url_missing_location_header(monkeypatch):
+    resp = MagicMock()
+    resp.is_redirect = True
+    resp.status_code = 302
+    resp.headers = {}
+    monkeypatch.setattr("pyscv.net.httpx.head", lambda *_a, **_kw: resp)
+    with pytest.raises(ValueError, match="missing Location header"):
+        resolve_url("https://github.com/file.whl")
+
+
+# -- atomic_download -------------------------------------------------------
+
+
+@pytest.fixture()
+def no_redirects(monkeypatch):
+    """Mock resolve_url to return the URL unchanged (no redirects)."""
+    monkeypatch.setattr("pyscv.net.resolve_url", lambda url, **_kw: url)
+
+
+def _make_mock_stream(chunks: list[bytes]):
+    """Create a mock context manager for httpx.stream."""
+    stream = MagicMock()
+    stream.raise_for_status = MagicMock()
+    stream.is_redirect = False
+    stream.iter_bytes.return_value = chunks
+    stream.__enter__ = MagicMock(return_value=stream)
+    stream.__exit__ = MagicMock(return_value=False)
+    return stream
+
+
+def test_atomic_download_writes_complete_file(tmp_path, monkeypatch, no_redirects):
+    dest = tmp_path / "output.whl"
+    monkeypatch.setattr(
+        "pyscv.net.httpx.stream",
+        lambda *_a, **_kw: _make_mock_stream([b"chunk1", b"chunk2"]),
+    )
+    atomic_download("https://github.com/f.whl", dest)
+    assert dest.read_bytes() == b"chunk1chunk2"
+
+
+def test_atomic_download_no_partial_on_status_error(tmp_path, monkeypatch, no_redirects):
+    dest = tmp_path / "output.whl"
+    stream = MagicMock()
+    stream.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "500", request=MagicMock(), response=MagicMock(status_code=500)
+    )
+    stream.__enter__ = MagicMock(return_value=stream)
+    stream.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr("pyscv.net.httpx.stream", lambda *_a, **_kw: stream)
+    with pytest.raises(httpx.HTTPStatusError):
+        atomic_download("https://github.com/f.whl", dest)
+    assert not dest.exists()
+
+
+def test_atomic_download_no_partial_on_stream_error(tmp_path, monkeypatch, no_redirects):
+    """If iter_bytes fails mid-write, dest must not exist."""
+    dest = tmp_path / "output.whl"
+
+    def exploding_iter():
+        yield b"partial"
+        raise ConnectionError
+
+    stream = MagicMock()
+    stream.raise_for_status = MagicMock()
+    stream.is_redirect = False
+    stream.iter_bytes = exploding_iter
+    stream.__enter__ = MagicMock(return_value=stream)
+    stream.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr("pyscv.net.httpx.stream", lambda *_a, **_kw: stream)
+    with pytest.raises(ConnectionError):
+        atomic_download("https://github.com/f.whl", dest)
+    assert not dest.exists()
+
+
+def test_atomic_download_rejects_unexpected_redirect(tmp_path, monkeypatch, no_redirects):
+    dest = tmp_path / "output.whl"
+    stream = MagicMock()
+    stream.raise_for_status = MagicMock()
+    stream.is_redirect = True
+    stream.__enter__ = MagicMock(return_value=stream)
+    stream.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr("pyscv.net.httpx.stream", lambda *_a, **_kw: stream)
+    with pytest.raises(ValueError, match="Unexpected redirect"):
+        atomic_download("https://github.com/f.whl", dest)
+    assert not dest.exists()
+
+
+# -- run_gh ----------------------------------------------------------------
+
+
+def test_run_gh_returns_completed_process(monkeypatch):
+    monkeypatch.setattr("pyscv.net.shutil.which", lambda _: "/usr/bin/gh")
+    monkeypatch.setattr(
+        "pyscv.net.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess(
+            args=a[0], returncode=0, stdout="ok", stderr=""
+        ),
+    )
+    result = run_gh(["version"])
+    assert result.returncode == 0
+    assert result.stdout == "ok"
+
+
+def test_run_gh_nonzero_exit(monkeypatch):
+    monkeypatch.setattr("pyscv.net.shutil.which", lambda _: "/usr/bin/gh")
+    monkeypatch.setattr(
+        "pyscv.net.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess(
+            args=a[0], returncode=1, stdout="", stderr="not found"
+        ),
+    )
+    result = run_gh(["release", "download", "v99"])
+    assert result.returncode == 1
+    assert "not found" in result.stderr
+
+
+def test_run_gh_falls_back_to_bare_gh(monkeypatch):
+    monkeypatch.setattr("pyscv.net.shutil.which", lambda _: None)
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("pyscv.net.subprocess.run", fake_run)
+    run_gh(["version"])
+    assert captured["cmd"][0] == "gh"

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 from unittest.mock import MagicMock
 
 import httpx
@@ -11,7 +10,6 @@ import pytest
 from pyscv.net import (
     atomic_download,
     resolve_url,
-    run_gh,
     safe_filename,
     validate_url,
 )
@@ -190,45 +188,3 @@ def test_atomic_download_rejects_unexpected_redirect(tmp_path, monkeypatch, no_r
     with pytest.raises(ValueError, match="Unexpected redirect"):
         atomic_download("https://github.com/f.whl", dest)
     assert not dest.exists()
-
-
-# -- run_gh ----------------------------------------------------------------
-
-
-def test_run_gh_returns_completed_process(monkeypatch):
-    monkeypatch.setattr("pyscv.net.shutil.which", lambda _: "/usr/bin/gh")
-    monkeypatch.setattr(
-        "pyscv.net.subprocess.run",
-        lambda *a, **kw: subprocess.CompletedProcess(
-            args=a[0], returncode=0, stdout="ok", stderr=""
-        ),
-    )
-    result = run_gh(["version"])
-    assert result.returncode == 0
-    assert result.stdout == "ok"
-
-
-def test_run_gh_nonzero_exit(monkeypatch):
-    monkeypatch.setattr("pyscv.net.shutil.which", lambda _: "/usr/bin/gh")
-    monkeypatch.setattr(
-        "pyscv.net.subprocess.run",
-        lambda *a, **kw: subprocess.CompletedProcess(
-            args=a[0], returncode=1, stdout="", stderr="not found"
-        ),
-    )
-    result = run_gh(["release", "download", "v99"])
-    assert result.returncode == 1
-    assert "not found" in result.stderr
-
-
-def test_run_gh_falls_back_to_bare_gh(monkeypatch):
-    monkeypatch.setattr("pyscv.net.shutil.which", lambda _: None)
-    captured = {}
-
-    def fake_run(cmd, **kw):
-        captured["cmd"] = cmd
-        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr("pyscv.net.subprocess.run", fake_run)
-    run_gh(["version"])
-    assert captured["cmd"][0] == "gh"


### PR DESCRIPTION
## Summary

- Extract shared networking primitives from `download_artifacts.py` into `src/pyscv/net.py` (`validate_url`, `safe_filename`, `resolve_url`, `atomic_download`)
- Create `src/pyscv/download_proofs.py` — proof downloader with GitHub attestations (REST API), PyPI provenance (Integrity API), and cosign bundle extraction (#121)
- Create `scripts/download_proofs.py` thin wrapper
- Add `pyscv` to pytest `--cov` and `coverage.run.source_pkgs`
- Split networking tests into `tests/test_net.py`
- 100% branch coverage on all pyscv modules (144 tests)

### Key design decisions

- **No `gh` CLI dependency** — uses GitHub REST API (`/repos/{slug}/attestations/sha256:{digest}`) directly via httpx
- **Hard failures** — missing attestations, download errors, and API failures all abort the process (no silent skips)
- **Per-version proof directories** — `proofs/{version}/{github,pypi,testpypi}/`
- **Artifact copies** in each proof source dir for integrity checking

Closes #121

## Test plan

- [x] `uv run pytest tests/test_net.py tests/test_download_artifacts.py tests/test_download_proofs.py --cov=pyscv --cov-branch` — 144 passed, 100% coverage
- [x] `uv run pre-commit run --all-files` — all 25 hooks pass
- [ ] Manual: `uv run python scripts/download_proofs.py 0.4.2a10 --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a unified proof downloader and central networking primitives to support safe, auditable retrieval of supply‑chain proofs, refactors artifact-download logic to reuse those primitives, and wires the new pyscv package into testing/coverage (closes #121). It introduces pyscv.net (networking helpers), a full proof-downloader pyscv.download_proofs with a Typer CLI, a thin executable wrapper script, comprehensive tests for the new modules, and coverage/config updates to include pyscv. Tests for pyscv modules reported full branch coverage in the run included with the PR.

## Key additions

- src/pyscv/net.py
  - Central networking utilities and constants: ALLOWED_HOSTS, API_TIMEOUT, DOWNLOAD_TIMEOUT, MAX_REDIRECTS.
  - gh_api_headers(): builds GitHub API request headers and reads GITHUB_TOKEN or GH_TOKEN at call time.
  - validate_url(url): enforces HTTPS and hostname allowlist.
  - safe_filename(name): rejects path traversal and separators; returns a normalized basename.
  - resolve_url(url, timeout=API_TIMEOUT): manual per-hop redirect inspection with Location validation and per-hop host re-validation; enforces MAX_REDIRECTS.
  - atomic_download(url, dest): resolves final URL, streams to a temp file, and atomically replaces dest; rejects redirect-like final responses.

- src/pyscv/download_proofs.py
  - End-to-end proof downloader storing proofs under proofs/{version}/{github,pypi,testpypi}/ and keeping per-source copies of artifacts for integrity checks.
  - GitHub Release support: downloads release assets (SHA256SUMS, sigstore bundles, SBOMs, provenance, dists) and saves artifact copies.
  - GitHub Attestation API: computes SHA256 over copied artifacts, queries /attestations/sha256:{digest}, writes raw attestations and extracts attestations[0]["bundle"] into per-artifact .gh-attestation-bundle.json (code documents single-bundle assumption and warns when multiple bundles are present).
  - PyPI/TestPyPI Integrity API (PEP 740): fetches provenance, writes provenance JSON, extracts .publish.attestation, and converts PEP 740 attestation into a cosign-compatible bundle (.cosign-bundle.json).
  - Orchestrator download_proofs(config, version, source, *, force=False, dry_run=False, verbose=False) with ProofSource enum (github, pypi, testpypi, all). Fail‑fast semantics: missing/malformed proofs or API/download errors return non-zero status.
  - Typer CLI (main/app) loads PyscvConfig from pyproject.toml, supports version/source/force/dry-run/verbose/pyproject, prints a header, and returns an appropriate exit code.

- scripts/download_proofs.py
  - Thin executable wrapper delegating to pyscv.download_proofs.app().

- Integration & configuration
  - pyproject.toml: adds pyscv to pytest coverage (--cov=pyscv) and includes pyscv in coverage.run.source_pkgs; adds pyscv-related config (repo-slug, tag-prefix, proofs-dir) consumed by the downloader.
  - CHANGELOG.md: [Unreleased] updated to mention download_proofs.py, pyscv.net, and pyscv coverage inclusion.

## Refactorings

- src/pyscv/download_artifacts.py
  - Removed local network/IO helpers and constants (_validate_url, _safe_filename, _resolve_url, atomic_download, GH_API_HEADERS, etc.).
  - Replaced local helpers with imports from pyscv.net (resolve_url, safe_filename, atomic_download, gh_api_headers()) and updated call sites accordingly. gh_api_headers() is now callable to reflect runtime token reads.

## Tests

- Added tests/test_net.py: covers validate_url, safe_filename, resolve_url (redirect chains, missing Location, redirect limits), atomic_download semantics (streaming, atomic replace, failure paths), and gh_api_headers behavior (env token precedence and default Accept header).
- Added tests/test_download_proofs.py: comprehensive tests for download_proofs workflows (GitHub release downloads, attestation fetching & bundle extraction, PyPI/TestPyPI provenance fetching & transformation, orchestrator behaviors, CLI), including dry-run/force modes and failure modes (unsafe filenames, missing artifacts, malformed provenance/attestations, HTTP errors).
- Updated tests/test_download_artifacts.py: removed moved networking tests and updated monkeypatch targets to the imported pyscv.net functions.
- Reported results in the branch: 144 tests passed with 100% branch coverage on pyscv modules; pre-commit hooks passed. Manual dry-run validation of some flows remains TODO.

## Behavior & guarantees

- Strict failure semantics: unsafe filenames, unexpected hosts, redirect anomalies, missing/empty attestations or provenance, and download/API errors are hard failures (non-zero exit codes).
- Per-version, per-source proof directories with artifact copies enable offline integrity checks.
- No dependency on the GitHub CLI—GitHub REST API is used with runtime token-aware headers.
- CLI options: --force (overwrite), --source (github|pypi|testpypi|all), --dry-run, and verbose output.

## Notes / review points

- The implementation extracts only the first attestation bundle (attestations[0]["bundle"]) into the .gh-attestation-bundle.json/.cosign-bundle.json files and preserves the full attestations list in the raw .gh-attestation.json/provenance JSONs; the code documents this assumption and warns if multiple bundles are present.
- Missing or malformed provenance/attestation data is treated as an error (hard failure) by design to preserve strict supply‑chain verification semantics.
- Manual dry-run checks for some end-to-end flows remain TODO.

## Closes

- Closes issue #121
<!-- end of auto-generated comment: release notes by coderabbit.ai -->