### PR TITLE
chore(security): adopt OpenSSF governance scaffolding

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,62 @@
+# Branch Protection Setup Guide
+
+Follow the [OpenSSF SCM Best Practices Guide](https://best.openssf.org/SCM-BestPractices/)
+to configure branch protection for your repository.
+
+## Recommended Settings for `main` / `master` branch
+
+### Required (OpenSSF Scorecard checks these)
+
+- [x] **Require pull request reviews before merging**
+  - Require at least 1 approving review
+  - Dismiss stale pull request approvals when new commits are pushed
+  - Require review from Code Owners
+
+- [x] **Require status checks to pass before merging**
+  - Require branches to be up to date before merging
+  - Add your CI/test workflow as a required check
+
+- [x] **Require signed commits** (if using Sigstore/GPG)
+
+- [x] **Do not allow force pushes**
+
+- [x] **Do not allow deletions**
+
+### Recommended
+
+- [x] **Require conversation resolution before merging**
+- [x] **Require linear history** (encourages rebase/squash merges)
+- [x] **Include administrators** in branch protection rules
+
+## How to Set Up
+
+### Via GitHub UI
+1. Go to **Settings** > **Branches**
+2. Click **Add branch protection rule**
+3. Set **Branch name pattern** to `main` (or `master`)
+4. Enable the settings listed above
+5. Click **Create** / **Save changes**
+
+### Via GitHub CLI
+```bash
+gh api repos/{owner}/{repo}/branches/main/protection \
+  --method PUT \
+  --field required_pull_request_reviews='{"required_approving_review_count":1,"dismiss_stale_reviews":true}' \
+  --field required_status_checks='{"strict":true,"contexts":["ci"]}' \
+  --field enforce_admins=true \
+  --field restrictions=null \
+  --field allow_force_pushes=false \
+  --field allow_deletions=false
+```
+
+## Verification
+
+After setting up branch protection, you can verify your configuration
+using [OpenSSF Scorecard](https://scorecard.dev/):
+
+```bash
+scorecard --repo=github.com/OWNER/REPO --checks=Branch-Protection
+```
+
+Or check the **Branch-Protection** check on your
+[Scorecard results page](https://scorecard.dev/viewer/).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ for alpha, `0.4.2b1` for beta, `0.4.2c1` for release candidate).
 
 ### Added
 
+- **OpenSSF governance**: added a `SECURITY-INSIGHTS.yml` manifest (OpenSSF
+  Security Insights v1) and a `.github/BRANCH_PROTECTION.md` setup guide, and
+  pulled in `ossguard` as a dev tool for bootstrapping/scanning against OpenSSF
+  best practices.
 - **Unified Markdown feed**: `compile-blog` now scans three content sources
   under `metadata/` — GLEP 42 news (`.txt`), blog posts (`metadata/posts/`),
   and security advisories (`metadata/glsa/`) — and compiles them into a

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,47 @@
+header:
+  schema-version: 1.0.0
+  expiry-date: '2027-05-11T07:09:28Z'
+  last-updated: '2026-05-11T07:09:28Z'
+  last-reviewed: '2026-05-11T07:09:28Z'
+  commit-hash: 98dad05ee8176b70c531e01b7b2cfefa7af0f5e3
+  changelog: CHANGELOG.md
+project-lifecycle:
+  status: active
+  bug-fixes-only: false
+contribution-policy:
+  accepts-pull-requests: true
+  accepts-automated-pull-requests: true
+  contributing-policy: CONTRIBUTING.md
+documentation:
+  README: README.md
+security-artifacts:
+  security-policy: SECURITY.md
+  signing:
+    enabled: true
+    tool: Sigstore
+security-testing:
+- tool-type: sast
+  tool-name: CodeQL
+  tool-url: https://codeql.github.com/
+  integration:
+    ci: true
+    before-release: false
+- tool-type: scorecard
+  tool-name: OpenSSF Scorecard
+  tool-url: https://securityscorecards.dev/
+  integration:
+    ci: true
+    before-release: false
+vulnerability-reporting:
+  accepts-vulnerability-reports: true
+  security-policy: SECURITY.md
+dependencies:
+  third-party-packages: true
+  dependencies-lists:
+  - requirements.txt
+  - pyproject.toml
+  automated-dependency-management:
+    enabled: true
+  sbom:
+  - sbom-type: build
+    sbom-format: spdx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "pip-audit>=2.7",
     "pre-commit>=4.0",
     "pypi-attestations>=0.0.18",
+    "ossguard>=0.1.4",
 ]
 
 [build-system]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,10 @@ annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
     # via pydantic
+anyio==4.13.0 \
+    --hash=sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708 \
+    --hash=sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc
+    # via httpx
 beautifulsoup4==4.14.3 \
     --hash=sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb \
     --hash=sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86
@@ -22,7 +26,10 @@ cachecontrol==0.14.4 \
 certifi==2026.2.25 \
     --hash=sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa \
     --hash=sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 cffi==2.0.0 ; platform_python_implementation != 'PyPy' \
     --hash=sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb \
     --hash=sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b \
@@ -278,6 +285,18 @@ gemato==20.12 \
     --hash=sha256:8fb8a83e63d9c46f4f722646d41e7ddf57d5c42fbe16a5ba8196b99f28cd943e \
     --hash=sha256:d691da405d690127f50c9ad7c57e9b14ec8cdb52246f2008c1b29f96b30258f5
     # via geek42
+h11==0.16.0 \
+    --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
+    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+    # via httpcore
+httpcore==1.0.9 \
+    --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
+    --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
+    # via httpx
+httpx==0.28.1 \
+    --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
+    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+    # via ossguard
 hypothesis==6.152.1 \
     --hash=sha256:40a3619d9e0cb97b018857c7986f75cf5de2e5ec0fa8a0b172d00747758f749e \
     --hash=sha256:4f4ed934eee295dd84ee97592477d23e8dc03e9f12ae0ee30a4e7c9ef3fca3b0
@@ -293,7 +312,9 @@ idna==3.11 \
     --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
     --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
     # via
+    #   anyio
     #   email-validator
+    #   httpx
     #   requests
 iniconfig==2.3.0 \
     --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
@@ -302,7 +323,9 @@ iniconfig==2.3.0 \
 jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-    # via geek42
+    # via
+    #   geek42
+    #   ossguard
 libcst==1.8.6 \
     --hash=sha256:04030ea4d39d69a65873b1d4d877def1c3951a7ada1824242539e399b8763d30 \
     --hash=sha256:08bd63a8ce674be431260649e70fca1d43f1554f1591eac657f403ff8ef82c7a \
@@ -478,6 +501,9 @@ nodeenv==1.10.0 \
     --hash=sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827 \
     --hash=sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb
     # via pre-commit
+ossguard==0.1.4 \
+    --hash=sha256:66e343c31c9d5b080087376a6bcc61649cf100fb69d85e60a984db4014d84619 \
+    --hash=sha256:ceb4d4cab5525c0bd7321929777d7485ac06debca9b7c992dfb54239cac252e3
 packageurl-python==0.17.6 \
     --hash=sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25 \
     --hash=sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9
@@ -523,6 +549,10 @@ pluggy==1.6.0 \
 pre-commit==4.5.1 \
     --hash=sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77 \
     --hash=sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61
+prompt-toolkit==3.0.52 \
+    --hash=sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855 \
+    --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955
+    # via questionary
 py-serializable==2.1.0 \
     --hash=sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103 \
     --hash=sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304
@@ -669,6 +699,7 @@ pyyaml==6.0.3 \
     --hash=sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6
     # via
     #   libcst
+    #   ossguard
     #   pre-commit
 pyyaml-ft==8.0.0 ; python_full_version < '3.14' \
     --hash=sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e \
@@ -689,6 +720,10 @@ pyyaml-ft==8.0.0 ; python_full_version < '3.14' \
     --hash=sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793 \
     --hash=sha256:e64fa5f3e2ceb790d50602b2fd4ec37abbd760a8c778e46354df647e7c5a4ebb
     # via libcst
+questionary==2.1.1 \
+    --hash=sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d \
+    --hash=sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59
+    # via ossguard
 requests==2.33.1 \
     --hash=sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517 \
     --hash=sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
@@ -725,6 +760,7 @@ rich==14.3.3 \
     --hash=sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b
     # via
     #   geek42
+    #   ossguard
     #   pip-audit
     #   sigstore
     #   textual
@@ -891,7 +927,9 @@ ty==0.0.31 \
 typer==0.24.1 \
     --hash=sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e \
     --hash=sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45
-    # via geek42
+    # via
+    #   geek42
+    #   ossguard
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
@@ -941,3 +979,7 @@ virtualenv==21.2.0 \
     --hash=sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098 \
     --hash=sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f
     # via pre-commit
+wcwidth==0.7.0 \
+    --hash=sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2 \
+    --hash=sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0
+    # via prompt-toolkit

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,18 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -420,6 +432,7 @@ dev = [
     { name = "beautifulsoup4" },
     { name = "hypothesis" },
     { name = "mutmut" },
+    { name = "ossguard" },
     { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pypi-attestations" },
@@ -449,6 +462,7 @@ dev = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "hypothesis", specifier = ">=6.100" },
     { name = "mutmut", specifier = ">=3.5" },
+    { name = "ossguard", specifier = ">=0.1.4" },
     { name = "pip-audit", specifier = ">=2.7" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pypi-attestations", specifier = ">=0.0.18" },
@@ -468,6 +482,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c1/25/74f1efe893ff14be58e43d1c8dc4cf06912e2fce929ab84463a750358c75/gemato-20.12.tar.gz", hash = "sha256:8fb8a83e63d9c46f4f722646d41e7ddf57d5c42fbe16a5ba8196b99f28cd943e", size = 94139, upload-time = "2026-01-10T14:44:19.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/1f/b94df121d32b3802260deb662c1ea0ac716923f47f31c7ffef78f8b4d1b8/gemato-20.12-py3-none-any.whl", hash = "sha256:d691da405d690127f50c9ad7c57e9b14ec8cdb52246f2008c1b29f96b30258f5", size = 51988, upload-time = "2026-01-10T14:44:17.822Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -796,6 +847,23 @@ wheels = [
 ]
 
 [[package]]
+name = "ossguard"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "pyyaml" },
+    { name = "questionary" },
+    { name = "rich" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ea/9c3697ed78f61f69f5b671ccb17d23cd6d25da680781743b974f79d4f4be/ossguard-0.1.4.tar.gz", hash = "sha256:66e343c31c9d5b080087376a6bcc61649cf100fb69d85e60a984db4014d84619", size = 96082, upload-time = "2026-05-09T18:12:26.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/42/3d4755ce15547d84f1dc490e0007aec5657922b94160243b76c45c1a1a28/ossguard-0.1.4-py3-none-any.whl", hash = "sha256:ceb4d4cab5525c0bd7321929777d7485ac06debca9b7c992dfb54239cac252e3", size = 102008, upload-time = "2026-05-09T18:12:24.94Z" },
+]
+
+[[package]]
 name = "packageurl-python"
 version = "0.17.6"
 source = { registry = "https://pypi.org/simple" }
@@ -900,6 +968,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -1192,6 +1272,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/05/10/f42c48fa5153204f42eaa945e8d1fd7c10d6296841dcb2447bf7da1be5c4/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e", size = 810403, upload-time = "2025-06-10T15:32:11.051Z" },
     { url = "https://files.pythonhosted.org/packages/d5/d2/e369064aa51009eb9245399fd8ad2c562bd0bcd392a00be44b2a824ded7c/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3bb4b927929b0cb162fb1605392a321e3333e48ce616cdcfa04a839271373255", size = 835581, upload-time = "2025-06-10T15:32:12.897Z" },
     { url = "https://files.pythonhosted.org/packages/c0/28/26534bed77109632a956977f60d8519049f545abc39215d086e33a61f1f2/pyyaml_ft-8.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793", size = 171579, upload-time = "2025-06-10T15:32:14.34Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -1623,4 +1715,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]


### PR DESCRIPTION
Parks the OpenSSF best-practices bootstrap that was sitting uncommitted on the publish branch, off its own branch so `main` stays clear.

## What's here
- `SECURITY-INSIGHTS.yml` — OpenSSF Security Insights v1 manifest.
- `.github/BRANCH_PROTECTION.md` — Scorecard-aligned branch-protection setup guide.
- `ossguard` as a dev dependency (bootstrap/scan tool); `requirements-dev.txt` regenerated.

## Draft — open items
- Pre-push `pip-audit` was skipped: the 19 findings are pre-existing dev-dep CVEs (cryptography, pyjwt, msgpack, urllib3, ...) that Dependabot PRs #166–#169 already cover, not anything ossguard pulled in.
- **Decide before un-drafting:** keep `ossguard` as a dev dep (+8 transitive packages) or run it via `uvx`/`pipx` instead? None of its tree audited as vulnerable, but it is extra dev surface.